### PR TITLE
Fix Text Overflow, OverlayBuilder's Builder Update, and Use Root Navigator Overlay

### DIFF
--- a/lib/get_position.dart
+++ b/lib/get_position.dart
@@ -28,8 +28,13 @@ import 'package:flutter/material.dart';
 
 class GetPosition {
   final GlobalKey key;
+  final EdgeInsetsGeometry padding;
 
-  GetPosition({this.key});
+  GetPosition({this.key, this.padding = const EdgeInsets.all(0.0)});
+
+  EdgeInsets get resolvedPadding {
+    return padding.resolve(Directionality.of(key.currentContext));
+  }
 
   Rect getRect() {
     RenderBox box = key.currentContext.findRenderObject();
@@ -39,10 +44,10 @@ class GetPosition {
     box.size.bottomRight(box.localToGlobal(const Offset(0.0, 0.0)));
 
     Rect rect = Rect.fromLTRB(
-      topLeft.dx,
-      topLeft.dy,
-      bottomRight.dx,
-      bottomRight.dy,
+      topLeft.dx - resolvedPadding.left,
+      topLeft.dy - resolvedPadding.top,
+      bottomRight.dx + resolvedPadding.right,
+      bottomRight.dy + resolvedPadding.bottom,
     );
     return rect;
   }
@@ -52,21 +57,21 @@ class GetPosition {
     RenderBox box = key.currentContext.findRenderObject();
     final bottomRight =
     box.size.bottomRight(box.localToGlobal(const Offset(0.0, 0.0)));
-    return bottomRight.dy;
+    return bottomRight.dy + resolvedPadding.bottom;
   }
 
   ///Get the top position of the widget
   double getTop() {
     RenderBox box = key.currentContext.findRenderObject();
     final topLeft = box.size.topLeft(box.localToGlobal(const Offset(0.0, 0.0)));
-    return topLeft.dy;
+    return topLeft.dy - resolvedPadding.top;
   }
 
   ///Get the left position of the widget
   double getLeft() {
     RenderBox box = key.currentContext.findRenderObject();
     final topLeft = box.size.topLeft(box.localToGlobal(const Offset(0.0, 0.0)));
-    return topLeft.dx;
+    return topLeft.dx - resolvedPadding.left;
   }
 
   ///Get the right position of the widget
@@ -74,7 +79,7 @@ class GetPosition {
     RenderBox box = key.currentContext.findRenderObject();
     final bottomRight =
     box.size.bottomRight(box.localToGlobal(const Offset(0.0, 0.0)));
-    return bottomRight.dx;
+    return bottomRight.dx + resolvedPadding.right;
   }
 
   double getHeight() {

--- a/lib/layout_overlays.dart
+++ b/lib/layout_overlays.dart
@@ -128,13 +128,13 @@ class _OverlayBuilderState extends State<OverlayBuilder> {
   @override
   void didUpdateWidget(OverlayBuilder oldWidget) {
     super.didUpdateWidget(oldWidget);
-    WidgetsBinding.instance.addPostFrameCallback((_) => syncWidgetAndOverlay());
+    WidgetsBinding.instance.addPostFrameCallback((_) => syncWidgetAndOverlay(oldWidget));
   }
 
   @override
   void reassemble() {
     super.reassemble();
-    WidgetsBinding.instance.addPostFrameCallback((_) => syncWidgetAndOverlay());
+    WidgetsBinding.instance.addPostFrameCallback((_) => syncWidgetAndOverlay(null));
   }
 
   @override
@@ -176,7 +176,15 @@ class _OverlayBuilderState extends State<OverlayBuilder> {
     }
   }
 
-  void syncWidgetAndOverlay() {
+  void syncWidgetAndOverlay(OverlayBuilder oldWidget) {
+    if (oldWidget != null &&
+        oldWidget.overlayBuilder != widget.overlayBuilder &&
+        widget.showOverlay) {
+      // remove current overlay first
+      hideOverlay();
+      // show overlay will create the new overlay
+      showOverlay();
+    }
     if (isShowingOverlay() && !widget.showOverlay) {
       hideOverlay();
     } else if (!isShowingOverlay() && widget.showOverlay) {

--- a/lib/layout_overlays.dart
+++ b/lib/layout_overlays.dart
@@ -162,8 +162,8 @@ class _OverlayBuilderState extends State<OverlayBuilder> {
   }
 
   void addToOverlay(OverlayEntry overlayEntry) async {
-    Overlay.of(context).insert(overlayEntry);
-    final overlay = Overlay.of(context);
+    final overlay = Navigator.of(context, rootNavigator:true).overlay;
+    overlay.insert(overlayEntry);
     if (overlayEntry == null)
       WidgetsBinding.instance
           .addPostFrameCallback((_) => overlay.insert(overlayEntry));

--- a/lib/showcase.dart
+++ b/lib/showcase.dart
@@ -54,6 +54,7 @@ class Showcase extends StatefulWidget {
   final VoidCallback onTargetClick;
   final bool disposeOnTap;
   final bool disableAnimation;
+  final EdgeInsetsGeometry spotlightPadding;
 
   const Showcase({@required this.key,
     @required this.child,
@@ -70,7 +71,8 @@ class Showcase extends StatefulWidget {
     this.onTargetClick,
     this.disposeOnTap,
     this.animationDuration = const Duration(milliseconds: 2000),
-    this.disableAnimation = false})
+    this.disableAnimation = false,
+    this.spotlightPadding = const EdgeInsets.all(0.0)})
       : height = null,
         width = null,
         container = null,
@@ -118,7 +120,8 @@ class Showcase extends StatefulWidget {
     this.onTargetClick,
     this.disposeOnTap,
     this.animationDuration = const Duration(milliseconds: 2000),
-    this.disableAnimation = false})
+    this.disableAnimation = false,
+    this.spotlightPadding = const EdgeInsets.all(0.0)})
       : this.showArrow = false,
         this.onToolTipClick = null,
         assert(overlayOpacity >= 0.0 && overlayOpacity <= 1.0,
@@ -170,7 +173,7 @@ class _ShowcaseState extends State<Showcase> with TickerProviderStateMixin {
       curve: Curves.easeInOut,
     );
 
-    position = GetPosition(key: widget.key);
+    position = GetPosition(key: widget.key, padding: widget.spotlightPadding);
   }
 
   @override

--- a/lib/tooltip_widget.dart
+++ b/lib/tooltip_widget.dart
@@ -24,6 +24,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:showcaseview/get_position.dart';
 
@@ -82,10 +84,11 @@ class ToolTipWidget extends StatelessWidget {
   double _getTooltipWidth() {
     double titleLength = title == null ? 0 : (title.length * 10.0);
     double descriptionLength = (description.length * 7.0);
-    if (titleLength > descriptionLength) {
-      return titleLength + 10;
+    double maxLength = max(titleLength, descriptionLength);
+    if (maxLength >= screenSize.width) {
+      return screenSize.width - 30;
     } else {
-      return descriptionLength + 10;
+      return maxLength + 10;
     }
   }
 
@@ -186,7 +189,7 @@ class ToolTipWidget extends StatelessWidget {
                         onTap: onTooltipTap,
                         child: Container(
                           width: _getTooltipWidth(),
-                          padding: EdgeInsets.symmetric(vertical: 8),
+                          padding: EdgeInsets.all(8.0),
                           color: tooltipColor,
                           child: Column(
                             crossAxisAlignment: CrossAxisAlignment.center,


### PR DESCRIPTION
The pull request introduces these changes:

- Fix text overflow: When text is longer than the screen width it overflows. The pull request fixes this by limiting the max width of the ToolTipWidget to screen width.

- Fix OverlayBuilder's didUpdateWidget: I noticed this issue when I changed the screen configuration of my device to landscape view, the overlay doesn't rebuild.

- Use root Navigator's Overlay: I had a page with a second navigator, and the showcase widget didn't work at all for me. Using the root navigator's overlay apparently fixed this. I believe this is due to how the overlay size and position are dependent on the screen size while the overlay (of the second navigator) is covering only part of the screen.
I also couldn't think of a situation where someone would want to use an overlay other than the root Navigator's overlay for showcasing their app so I just used the root Navigator.

- Support for the ability to add padding to spotlight