### PR TITLE
Add optional contentPadding

### DIFF
--- a/lib/showcase.dart
+++ b/lib/showcase.dart
@@ -40,6 +40,7 @@ class Showcase extends StatefulWidget {
   final ShapeBorder shapeBorder;
   final TextStyle titleTextStyle;
   final TextStyle descTextStyle;
+  final EdgeInsets contentPadding;
   final GlobalKey key;
   final Color overlayColor;
   final double overlayOpacity;
@@ -55,38 +56,40 @@ class Showcase extends StatefulWidget {
   final bool disposeOnTap;
   final bool disableAnimation;
 
-  const Showcase({@required this.key,
-    @required this.child,
-    this.title,
-    @required this.description,
-    this.shapeBorder,
-    this.overlayColor = Colors.black,
-    this.overlayOpacity = 0.75,
-    this.titleTextStyle,
-    this.descTextStyle,
-    this.showcaseBackgroundColor = Colors.white,
-    this.textColor = Colors.black,
-    this.showArrow = true,
-    this.onTargetClick,
-    this.disposeOnTap,
-    this.animationDuration = const Duration(milliseconds: 2000),
-    this.disableAnimation = false})
+  const Showcase(
+      {@required this.key,
+      @required this.child,
+      this.title,
+      @required this.description,
+      this.shapeBorder,
+      this.overlayColor = Colors.black,
+      this.overlayOpacity = 0.75,
+      this.titleTextStyle,
+      this.descTextStyle,
+      this.showcaseBackgroundColor = Colors.white,
+      this.textColor = Colors.black,
+      this.showArrow = true,
+      this.onTargetClick,
+      this.disposeOnTap,
+      this.animationDuration = const Duration(milliseconds: 2000),
+      this.disableAnimation = false,
+      this.contentPadding})
       : height = null,
         width = null,
         container = null,
         this.onToolTipClick = null,
         assert(overlayOpacity >= 0.0 && overlayOpacity <= 1.0,
-        "overlay opacity should be >= 0.0 and <= 1.0."),
+            "overlay opacity should be >= 0.0 and <= 1.0."),
         assert(
-        onTargetClick == null
-            ? true
-            : (disposeOnTap == null ? false : true),
-        "disposeOnTap is required if you're using onTargetClick"),
+            onTargetClick == null
+                ? true
+                : (disposeOnTap == null ? false : true),
+            "disposeOnTap is required if you're using onTargetClick"),
         assert(
-        disposeOnTap == null
-            ? true
-            : (onTargetClick == null ? false : true),
-        "onTargetClick is required if you're using disposeOnTap"),
+            disposeOnTap == null
+                ? true
+                : (onTargetClick == null ? false : true),
+            "onTargetClick is required if you're using disposeOnTap"),
         assert(key != null ||
             child != null ||
             title != null ||
@@ -101,28 +104,30 @@ class Showcase extends StatefulWidget {
             shapeBorder != null ||
             animationDuration != null);
 
-  const Showcase.withWidget({this.key,
-    @required this.child,
-    @required this.container,
-    @required this.height,
-    @required this.width,
-    this.title,
-    this.description,
-    this.shapeBorder,
-    this.overlayColor = Colors.black,
-    this.overlayOpacity = 0.75,
-    this.titleTextStyle,
-    this.descTextStyle,
-    this.showcaseBackgroundColor = Colors.white,
-    this.textColor = Colors.black,
-    this.onTargetClick,
-    this.disposeOnTap,
-    this.animationDuration = const Duration(milliseconds: 2000),
-    this.disableAnimation = false})
+  const Showcase.withWidget(
+      {this.key,
+      @required this.child,
+      @required this.container,
+      @required this.height,
+      @required this.width,
+      this.title,
+      this.description,
+      this.shapeBorder,
+      this.overlayColor = Colors.black,
+      this.overlayOpacity = 0.75,
+      this.titleTextStyle,
+      this.descTextStyle,
+      this.showcaseBackgroundColor = Colors.white,
+      this.textColor = Colors.black,
+      this.onTargetClick,
+      this.disposeOnTap,
+      this.animationDuration = const Duration(milliseconds: 2000),
+      this.disableAnimation = false,
+      this.contentPadding})
       : this.showArrow = false,
         this.onToolTipClick = null,
         assert(overlayOpacity >= 0.0 && overlayOpacity <= 1.0,
-        "overlay opacity should be >= 0.0 and <= 1.0."),
+            "overlay opacity should be >= 0.0 and <= 1.0."),
         assert(key != null ||
             child != null ||
             title != null ||
@@ -155,15 +160,15 @@ class _ShowcaseState extends State<Showcase> with TickerProviderStateMixin {
       duration: widget.animationDuration,
       vsync: this,
     )..addStatusListener((AnimationStatus status) {
-      if (status == AnimationStatus.completed) {
-        _slideAnimationController.reverse();
-      }
-      if (_slideAnimationController.isDismissed) {
-        if (!widget.disableAnimation) {
-          _slideAnimationController.forward();
+        if (status == AnimationStatus.completed) {
+          _slideAnimationController.reverse();
         }
-      }
-    });
+        if (_slideAnimationController.isDismissed) {
+          if (!widget.disableAnimation) {
+            _slideAnimationController.forward();
+          }
+        }
+      });
 
     _slideAnimation = CurvedAnimation(
       parent: _slideAnimationController,
@@ -223,12 +228,12 @@ class _ShowcaseState extends State<Showcase> with TickerProviderStateMixin {
     if (widget.disposeOnTap == true) {
       return widget.onTargetClick == null
           ? () {
-        ShowCaseWidget.of(context).dismiss();
-      }
+              ShowCaseWidget.of(context).dismiss();
+            }
           : () {
-        ShowCaseWidget.of(context).dismiss();
-        widget.onTargetClick();
-      };
+              ShowCaseWidget.of(context).dismiss();
+              widget.onTargetClick();
+            };
     } else {
       return widget.onTargetClick ?? _nextIfAny;
     }
@@ -238,21 +243,23 @@ class _ShowcaseState extends State<Showcase> with TickerProviderStateMixin {
     if (widget.disposeOnTap == true) {
       return widget.onToolTipClick == null
           ? () {
-        ShowCaseWidget.of(context).dismiss();
-      }
+              ShowCaseWidget.of(context).dismiss();
+            }
           : () {
-        ShowCaseWidget.of(context).dismiss();
-        widget.onToolTipClick();
-      };
+              ShowCaseWidget.of(context).dismiss();
+              widget.onToolTipClick();
+            };
     } else {
       return widget.onToolTipClick ?? () {};
     }
   }
 
-  buildOverlayOnTarget(Offset offset,
-      Size size,
-      Rect rectBound,
-      Size screenSize,) =>
+  buildOverlayOnTarget(
+    Offset offset,
+    Size size,
+    Rect rectBound,
+    Size screenSize,
+  ) =>
       Visibility(
         visible: _showShowCase,
         maintainAnimation: true,
@@ -295,6 +302,7 @@ class _ShowcaseState extends State<Showcase> with TickerProviderStateMixin {
               contentHeight: widget.height,
               contentWidth: widget.width,
               onTooltipTap: _getOnTooltipTap(),
+              contentPadding: widget.contentPadding,
             ),
           ],
         ),

--- a/lib/showcase.dart
+++ b/lib/showcase.dart
@@ -73,7 +73,7 @@ class Showcase extends StatefulWidget {
       this.disposeOnTap,
       this.animationDuration = const Duration(milliseconds: 2000),
       this.disableAnimation = false,
-      this.contentPadding})
+      this.contentPadding = const EdgeInsets.symmetric(vertical: 8)})
       : height = null,
         width = null,
         container = null,
@@ -123,7 +123,7 @@ class Showcase extends StatefulWidget {
       this.disposeOnTap,
       this.animationDuration = const Duration(milliseconds: 2000),
       this.disableAnimation = false,
-      this.contentPadding})
+      this.contentPadding = const EdgeInsets.symmetric(vertical: 8)})
       : this.showArrow = false,
         this.onToolTipClick = null,
         assert(overlayOpacity >= 0.0 && overlayOpacity <= 1.0,

--- a/lib/tooltip_widget.dart
+++ b/lib/tooltip_widget.dart
@@ -44,24 +44,25 @@ class ToolTipWidget extends StatelessWidget {
   final double contentWidth;
   static bool isArrowUp;
   final VoidCallback onTooltipTap;
+  final EdgeInsets contentPadding;
 
-  ToolTipWidget({
-    this.position,
-    this.offset,
-    this.screenSize,
-    this.title,
-    this.description,
-    this.animationOffset,
-    this.titleTextStyle,
-    this.descTextStyle,
-    this.container,
-    this.tooltipColor,
-    this.textColor,
-    this.showArrow,
-    this.contentHeight,
-    this.contentWidth,
-    this.onTooltipTap,
-  });
+  ToolTipWidget(
+      {this.position,
+      this.offset,
+      this.screenSize,
+      this.title,
+      this.description,
+      this.animationOffset,
+      this.titleTextStyle,
+      this.descTextStyle,
+      this.container,
+      this.tooltipColor,
+      this.textColor,
+      this.showArrow,
+      this.contentHeight,
+      this.contentWidth,
+      this.onTooltipTap,
+      this.contentPadding = const EdgeInsets.symmetric(vertical: 8)});
 
   bool isCloseToTopOrBottom(Offset position) {
     double height = 120;
@@ -179,14 +180,14 @@ class ToolTipWidget extends StatelessWidget {
                   color: Colors.transparent,
                   child: Container(
                     padding:
-                    EdgeInsets.only(top: paddingTop, bottom: paddingBottom),
+                        EdgeInsets.only(top: paddingTop, bottom: paddingBottom),
                     child: ClipRRect(
                       borderRadius: BorderRadius.circular(8),
                       child: GestureDetector(
                         onTap: onTooltipTap,
                         child: Container(
                           width: _getTooltipWidth(),
-                          padding: EdgeInsets.symmetric(vertical: 8),
+                          padding: contentPadding,
                           color: tooltipColor,
                           child: Column(
                             crossAxisAlignment: CrossAxisAlignment.center,
@@ -199,14 +200,14 @@ class ToolTipWidget extends StatelessWidget {
                                   children: <Widget>[
                                     title != null
                                         ? Text(
-                                      title,
-                                      style: titleTextStyle ??
-                                          Theme.of(context)
-                                              .textTheme
-                                              .title
-                                              .merge(TextStyle(
-                                              color: textColor)),
-                                    )
+                                            title,
+                                            style: titleTextStyle ??
+                                                Theme.of(context)
+                                                    .textTheme
+                                                    .title
+                                                    .merge(TextStyle(
+                                                        color: textColor)),
+                                          )
                                         : Container(),
                                     Text(
                                       description,
@@ -214,7 +215,8 @@ class ToolTipWidget extends StatelessWidget {
                                           Theme.of(context)
                                               .textTheme
                                               .subtitle
-                                              .merge(TextStyle(color: textColor)),
+                                              .merge(
+                                                  TextStyle(color: textColor)),
                                     ),
                                   ],
                                 ),
@@ -281,15 +283,15 @@ class ToolTipWidget extends StatelessWidget {
           ).animate(animationOffset),
           child: isArrowUp
               ? Icon(
-            Icons.arrow_drop_up,
-            color: tooltipColor,
-            size: 50,
-          )
+                  Icons.arrow_drop_up,
+                  color: tooltipColor,
+                  size: 50,
+                )
               : Icon(
-            Icons.arrow_drop_down,
-            color: tooltipColor,
-            size: 50,
-          ),
+                  Icons.arrow_drop_down,
+                  color: tooltipColor,
+                  size: 50,
+                ),
         ),
       ),
     );

--- a/lib/tooltip_widget.dart
+++ b/lib/tooltip_widget.dart
@@ -62,7 +62,7 @@ class ToolTipWidget extends StatelessWidget {
       this.contentHeight,
       this.contentWidth,
       this.onTooltipTap,
-      this.contentPadding = const EdgeInsets.symmetric(vertical: 8)});
+      this.contentPadding});
 
   bool isCloseToTopOrBottom(Offset position) {
     double height = 120;


### PR DESCRIPTION
This PR adds a contentPadding property to the TooltipWidget. It also adds it to the Showcase, and gets passed through. The default value remains `EdgeInsets.symmetric(vertical: 8)` just as it is set in the code right now, but it's not hardcoded. So it turns this:

![before](https://user-images.githubusercontent.com/6227145/89061532-d98ddd00-d332-11ea-8f40-68755c5b8f50.png)

Into this:

![after](https://user-images.githubusercontent.com/6227145/89061360-90d62400-d332-11ea-943a-b4ae545c2a17.png)

This is useful in scenarios where don't need to use your own widget, but you want your text to appear nicely to users.