### PR TITLE
fix disableAnimation

### DIFF
--- a/lib/src/showcase.dart
+++ b/lib/src/showcase.dart
@@ -188,7 +188,9 @@ class _ShowcaseState extends State<Showcase> with TickerProviderStateMixin {
     });
 
     if (activeStep == widget.key) {
-      _slideAnimationController.forward();
+      if (!widget.disableAnimation) {
+        _slideAnimationController.forward();
+      }
       if (ShowCaseWidget.of(context)!.autoPlay) {
         timer = Timer(
             Duration(


### PR DESCRIPTION
In some cases the showcase widget gets animated altough `disableAnimation` is set to `true`.

I fixed this behavior by adding a check before starting the animation controller.