### PR TITLE
fixed context being access after widget has been disposed

### DIFF
--- a/lib/src/layout_overlays.dart
+++ b/lib/src/layout_overlays.dart
@@ -129,15 +129,17 @@ class _OverlayBuilderState extends State<OverlayBuilder> {
   @override
   void didUpdateWidget(OverlayBuilder oldWidget) {
     super.didUpdateWidget(oldWidget);
-    WidgetsBinding.instance!
-        .addPostFrameCallback((_) => syncWidgetAndOverlay());
+    WidgetsBinding.instance!.addPostFrameCallback((_) {
+      if (isShowingOverlay()) syncWidgetAndOverlay();
+    });
   }
 
   @override
   void reassemble() {
     super.reassemble();
-    WidgetsBinding.instance!
-        .addPostFrameCallback((_) => syncWidgetAndOverlay());
+    WidgetsBinding.instance!.addPostFrameCallback((_) {
+      if (isShowingOverlay()) syncWidgetAndOverlay();
+    });
   }
 
   @override


### PR DESCRIPTION
If the ShowCase widget is rebuild in quick succession the frame callback is still called but state will have since been disposed. This fix simply checks if the _overlayEntry has been set to null i.e. the state was disposed.

##### The Error:
```
[VERBOSE-2:shell.cc(103)] Dart Unhandled Exception: This widget has been unmounted, so the State no longer has a context (and should be considered defunct).
Consider canceling any active work during "dispose" or using the "mounted" getter to determine if the State is still active., stack trace: #0      State.context.<anonymous closure> (package:flutter/src/widgets/framework.dart:909:9)
#1      State.context (package:flutter/src/widgets/framework.dart:915:6)
#2      _OverlayBuilderState.addToOverlay (package:showcaseview/src/layout_overlays.dart:172:34)
#3      _OverlayBuilderState.showOverlay (package:showcaseview/src/layout_overlays.dart:164:7)
#4      _OverlayBuilderState.syncWidgetAndOverlay (package:showcaseview/src/layout_overlays.dart:187:7)
#5      _OverlayBuilderState.reassemble.<anonymous closure> (package:showcaseview/src/layout_overlays.dart:143:9)
#6      SchedulerBinding._invokeFrameCallback (package:flutter/src/scheduler/binding.dart:1144:15)
#7      SchedulerBinding.handleDrawFrame (package:flutter/src/scheduler/binding.dart:1090:9)
#8      SchedulerBinding.scheduleWarmUpFrame.<anonymous closure> (package:flutter/src/scheduler/binding.dart:865:7)
#9      Timer._createTimer.<anonymous closure> (dart:async-patch/timer_patch.dart:18:15)
#10     _Timer._runTimers (dart:isolate-patch/timer_impl.dart:395:19)
#11     _Timer._handleMessage (dart:isolate-patch/timer_impl.dart:426:5)
#12     _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:184:12)
```