### PR TITLE
adds centerwidget (nullable)

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -161,6 +161,10 @@ class _MailPageState extends State<MailPage> {
                                     Showcase(
                                       key: _one,
                                       description: 'Tap to see menu options',
+                                      centerWidget: Image.asset(
+                                        "assets/simform.png",
+                                        height: 150,
+                                      ),
                                       child: Icon(
                                         Icons.menu,
                                         color: Theme.of(context).primaryColor,

--- a/lib/src/showcase.dart
+++ b/lib/src/showcase.dart
@@ -38,6 +38,7 @@ class Showcase extends StatefulWidget {
   final Widget child;
   final String? title;
   final String? description;
+  final Widget? centerWidget;
   final ShapeBorder? shapeBorder;
   final TextStyle? titleTextStyle;
   final TextStyle? descTextStyle;
@@ -62,6 +63,7 @@ class Showcase extends StatefulWidget {
       required this.child,
       this.title,
       required this.description,
+      this.centerWidget,
       this.shapeBorder,
       this.overlayColor = Colors.black,
       this.overlayOpacity = 0.75,
@@ -102,6 +104,7 @@ class Showcase extends StatefulWidget {
     required this.width,
     this.title,
     this.description,
+    this.centerWidget,
     this.shapeBorder,
     this.overlayColor = Colors.black,
     this.overlayOpacity = 0.75,
@@ -274,6 +277,7 @@ class _ShowcaseState extends State<Showcase> with TickerProviderStateMixin {
               onTap: _getOnTargetTap,
               shapeBorder: widget.shapeBorder,
             ),
+            if (widget.centerWidget != null) Center(child: widget.centerWidget),
             ToolTipWidget(
               position: position,
               offset: offset,


### PR DESCRIPTION
Adds a attribute centerWidget to display a widget in center of the screen. Usually brands want to display a brand icon or character while they show the showcase. 
This adds that feature.

The centerWidget is anyways nullable so this can be ignored when not needed.

![image](https://user-images.githubusercontent.com/63007835/131717813-ef9ac462-8203-482e-9306-86870748b763.png)
