### PR TITLE
Fixed arrow showing with 'showArrow: false' set in the widget.

### DIFF
--- a/lib/src/tooltip_widget.dart
+++ b/lib/src/tooltip_widget.dart
@@ -197,36 +197,38 @@ class _ToolTipWidgetState extends State<ToolTipWidget> {
     final arrowHeight = 9.0;
 
     final arrowWidget = !widget.showArrow!
-        ? SizedBox.shrink()
-        : Positioned(
-            left: _getLeft() == null
-                ? null
-                : max<double>(
-                    (widget.position!.getCenter() -
-                        (arrowWidth / 2) -
-                        (_getLeft() ?? 0)),
-                    4),
-            right: _getLeft() == null
-                ? max<double>(
-                    (MediaQuery.of(context).size.width -
-                            widget.position!.getCenter()) -
-                        (_getRight() ?? 0) -
-                        (arrowWidth / 2),
-                    4)
-                : null,
-            child: CustomPaint(
-              painter: _Arrow(
-                strokeColor: widget.tooltipColor!,
-                strokeWidth: 10,
-                paintingStyle: PaintingStyle.fill,
-                isUpArrow: ToolTipWidget.isArrowUp,
+        ? []
+        : [
+            Positioned(
+              left: _getLeft() == null
+                  ? null
+                  : max<double>(
+                      (widget.position!.getCenter() -
+                          (arrowWidth / 2) -
+                          (_getLeft() ?? 0)),
+                      4),
+              right: _getLeft() == null
+                  ? max<double>(
+                      (MediaQuery.of(context).size.width -
+                              widget.position!.getCenter()) -
+                          (_getRight() ?? 0) -
+                          (arrowWidth / 2),
+                      4)
+                  : null,
+              child: CustomPaint(
+                painter: _Arrow(
+                  strokeColor: widget.tooltipColor!,
+                  strokeWidth: 10,
+                  paintingStyle: PaintingStyle.fill,
+                  isUpArrow: ToolTipWidget.isArrowUp,
+                ),
+                child: SizedBox(
+                  height: arrowHeight,
+                  width: arrowWidth,
+                ),
               ),
-              child: SizedBox(
-                height: arrowHeight,
-                width: arrowWidth,
-              ),
-            ),
-          );
+            )
+          ];
 
     if (widget.container == null) {
       return Positioned(
@@ -255,7 +257,7 @@ class _ToolTipWidgetState extends State<ToolTipWidget> {
                           ? Alignment.bottomRight
                           : Alignment.bottomLeft,
                   children: [
-                    arrowWidget,
+                    ...arrowWidget,
                     Padding(
                       padding: EdgeInsets.only(
                         top: ToolTipWidget.isArrowUp ? arrowHeight - 1 : 0,

--- a/lib/src/tooltip_widget.dart
+++ b/lib/src/tooltip_widget.dart
@@ -197,6 +197,8 @@ class _ToolTipWidgetState extends State<ToolTipWidget> {
     final arrowHeight = 9.0;
 
     if (widget.container == null) {
+      print(
+          'painting arrow widget: _getRight()(): ${_getRight()}, pos: ${(MediaQuery.of(context).size.width - widget.position!.getCenter()) - (_getRight() ?? 0) - (arrowWidth / 2)} ');
       return Positioned(
         top: contentY,
         left: _getLeft(),
@@ -226,14 +228,18 @@ class _ToolTipWidgetState extends State<ToolTipWidget> {
                     Positioned(
                       left: _getLeft() == null
                           ? null
-                          : (widget.position!.getCenter() -
-                              (arrowWidth / 2) -
-                              (_getLeft() ?? 0)),
+                          : max<double>(
+                              (widget.position!.getCenter() -
+                                  (arrowWidth / 2) -
+                                  (_getLeft() ?? 0)),
+                              4),
                       right: _getLeft() == null
-                          ? (MediaQuery.of(context).size.width -
-                                  widget.position!.getCenter()) -
-                              (_getRight() ?? 0) -
-                              (arrowWidth / 2)
+                          ? max<double>(
+                              (MediaQuery.of(context).size.width -
+                                      widget.position!.getCenter()) -
+                                  (_getRight() ?? 0) -
+                                  (arrowWidth / 2),
+                              4)
                           : null,
                       child: CustomPaint(
                         painter: _Arrow(

--- a/lib/src/tooltip_widget.dart
+++ b/lib/src/tooltip_widget.dart
@@ -185,8 +185,10 @@ class _ToolTipWidgetState extends State<ToolTipWidget> {
     final num contentFractionalOffset =
         contentOffsetMultiplier.clamp(-1.0, 0.0);
 
-    var paddingTop = ToolTipWidget.isArrowUp ? 22.0 : 0.0;
-    var paddingBottom = ToolTipWidget.isArrowUp ? 0.0 : 27.0;
+    var paddingTop =
+        ToolTipWidget.isArrowUp && widget.showArrow! == true ? 22.0 : 0.0;
+    var paddingBottom =
+        ToolTipWidget.isArrowUp && widget.showArrow! == true ? 0.0 : 27.0;
 
     if (!widget.showArrow!) {
       paddingTop = 10;

--- a/lib/src/tooltip_widget.dart
+++ b/lib/src/tooltip_widget.dart
@@ -185,10 +185,8 @@ class _ToolTipWidgetState extends State<ToolTipWidget> {
     final num contentFractionalOffset =
         contentOffsetMultiplier.clamp(-1.0, 0.0);
 
-    var paddingTop =
-        ToolTipWidget.isArrowUp && widget.showArrow! == true ? 22.0 : 0.0;
-    var paddingBottom =
-        ToolTipWidget.isArrowUp && widget.showArrow! == true ? 0.0 : 27.0;
+    var paddingTop = ToolTipWidget.isArrowUp ? 22.0 : 0.0;
+    var paddingBottom = ToolTipWidget.isArrowUp ? 0.0 : 27.0;
 
     if (!widget.showArrow!) {
       paddingTop = 10;

--- a/lib/src/tooltip_widget.dart
+++ b/lib/src/tooltip_widget.dart
@@ -196,9 +196,39 @@ class _ToolTipWidgetState extends State<ToolTipWidget> {
     final arrowWidth = 18.0;
     final arrowHeight = 9.0;
 
+    final arrowWidget = !widget.showArrow!
+        ? SizedBox.shrink()
+        : Positioned(
+            left: _getLeft() == null
+                ? null
+                : max<double>(
+                    (widget.position!.getCenter() -
+                        (arrowWidth / 2) -
+                        (_getLeft() ?? 0)),
+                    4),
+            right: _getLeft() == null
+                ? max<double>(
+                    (MediaQuery.of(context).size.width -
+                            widget.position!.getCenter()) -
+                        (_getRight() ?? 0) -
+                        (arrowWidth / 2),
+                    4)
+                : null,
+            child: CustomPaint(
+              painter: _Arrow(
+                strokeColor: widget.tooltipColor!,
+                strokeWidth: 10,
+                paintingStyle: PaintingStyle.fill,
+                isUpArrow: ToolTipWidget.isArrowUp,
+              ),
+              child: SizedBox(
+                height: arrowHeight,
+                width: arrowWidth,
+              ),
+            ),
+          );
+
     if (widget.container == null) {
-      print(
-          'painting arrow widget: _getRight()(): ${_getRight()}, pos: ${(MediaQuery.of(context).size.width - widget.position!.getCenter()) - (_getRight() ?? 0) - (arrowWidth / 2)} ');
       return Positioned(
         top: contentY,
         left: _getLeft(),
@@ -225,35 +255,7 @@ class _ToolTipWidgetState extends State<ToolTipWidget> {
                           ? Alignment.bottomRight
                           : Alignment.bottomLeft,
                   children: [
-                    Positioned(
-                      left: _getLeft() == null
-                          ? null
-                          : max<double>(
-                              (widget.position!.getCenter() -
-                                  (arrowWidth / 2) -
-                                  (_getLeft() ?? 0)),
-                              4),
-                      right: _getLeft() == null
-                          ? max<double>(
-                              (MediaQuery.of(context).size.width -
-                                      widget.position!.getCenter()) -
-                                  (_getRight() ?? 0) -
-                                  (arrowWidth / 2),
-                              4)
-                          : null,
-                      child: CustomPaint(
-                        painter: _Arrow(
-                          strokeColor: widget.tooltipColor!,
-                          strokeWidth: 10,
-                          paintingStyle: PaintingStyle.fill,
-                          isUpArrow: ToolTipWidget.isArrowUp,
-                        ),
-                        child: SizedBox(
-                          height: arrowHeight,
-                          width: arrowWidth,
-                        ),
-                      ),
-                    ),
+                    arrowWidget,
                     Padding(
                       padding: EdgeInsets.only(
                         top: ToolTipWidget.isArrowUp ? arrowHeight - 1 : 0,


### PR DESCRIPTION
 Also gave the arrow a minimum offset from the tooltip border, as it was overlapping the rounded corners on some elements.
 
 Before: 
![before](https://user-images.githubusercontent.com/87186017/154229972-2f3f556e-b3d5-4946-863c-3a8b67fb16cd.png)

After: 
![after](https://user-images.githubusercontent.com/87186017/154229992-f6db23b2-2e8c-44cf-bf85-8ac6feef42e5.png)
 