### PR TITLE
Feature/scroll active showcase into view

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 30
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -56,6 +56,7 @@ class _MailPageState extends State<MailPage> {
   final GlobalKey _three = GlobalKey();
   final GlobalKey _four = GlobalKey();
   final GlobalKey _five = GlobalKey();
+  final GlobalKey _six = GlobalKey();
   List<Mail> mails = [];
 
   @override
@@ -64,7 +65,7 @@ class _MailPageState extends State<MailPage> {
     //Start showcase view after current widget frames are drawn.
     WidgetsBinding.instance!.addPostFrameCallback(
       (_) => ShowCaseWidget.of(context)!
-          .startShowCase([_one, _two, _three, _four, _five]),
+          .startShowCase([_one, _two, _three, _four, _five, _six]),
     );
     mails = [
       Mail(
@@ -246,7 +247,9 @@ class _MailPageState extends State<MailPage> {
                 physics: const BouncingScrollPhysics(),
                 itemBuilder: (context, index) {
                   if (index == 0) {
-                    return showcaseMailTile(context);
+                    return showcaseMailTile(_three, true, context);
+                  } else if (index == mails.length - 1) {
+                    return showcaseMailTile(_six, false, context);
                   }
                   return MailTile(mails[index % mails.length]);
                 },
@@ -265,7 +268,7 @@ class _MailPageState extends State<MailPage> {
           onPressed: () {
             setState(() {
               ShowCaseWidget.of(context)!
-                  .startShowCase([_one, _two, _three, _four, _five]);
+                  .startShowCase([_one, _two, _three, _four, _five, _six]);
             });
           },
           child: const Icon(
@@ -276,7 +279,8 @@ class _MailPageState extends State<MailPage> {
     );
   }
 
-  GestureDetector showcaseMailTile(BuildContext context) {
+  GestureDetector showcaseMailTile(GlobalKey<State<StatefulWidget>> key,
+      bool showCaseDetail, BuildContext context) {
     return GestureDetector(
       onTap: () {
         Navigator.push<void>(
@@ -289,7 +293,7 @@ class _MailPageState extends State<MailPage> {
       child: Container(
         padding: const EdgeInsets.symmetric(vertical: 8),
         child: Showcase(
-          key: _three,
+          key: key,
           description: 'Tap to check mail',
           disposeOnTap: true,
           onTargetClick: () {
@@ -315,64 +319,47 @@ class _MailPageState extends State<MailPage> {
                   child: Row(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: <Widget>[
-                      Showcase.withWidget(
-                        key: _four,
-                        height: 50,
-                        width: 140,
-                        shapeBorder: const CircleBorder(),
-                        radius: const BorderRadius.all(Radius.circular(150)),
-                        container: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: <Widget>[
-                            Container(
-                              width: 45,
-                              height: 45,
-                              decoration: const BoxDecoration(
-                                shape: BoxShape.circle,
-                                color: Color(0xffFCD8DC),
-                              ),
-                              child: Center(
-                                child: Text(
-                                  'S',
-                                  style: TextStyle(
-                                    color: Theme.of(context).primaryColor,
-                                    fontWeight: FontWeight.bold,
-                                    fontSize: 16,
+                      if (showCaseDetail)
+                        Showcase.withWidget(
+                          key: _four,
+                          height: 50,
+                          width: 140,
+                          shapeBorder: const CircleBorder(),
+                          radius: const BorderRadius.all(Radius.circular(150)),
+                          container: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: <Widget>[
+                              Container(
+                                width: 45,
+                                height: 45,
+                                decoration: const BoxDecoration(
+                                  shape: BoxShape.circle,
+                                  color: Color(0xffFCD8DC),
+                                ),
+                                child: Center(
+                                  child: Text(
+                                    'S',
+                                    style: TextStyle(
+                                      color: Theme.of(context).primaryColor,
+                                      fontWeight: FontWeight.bold,
+                                      fontSize: 16,
+                                    ),
                                   ),
                                 ),
                               ),
-                            ),
-                            const SizedBox(
-                              height: 10,
-                            ),
-                            const Text(
-                              "Your sender's profile ",
-                              style: TextStyle(color: Colors.white),
-                            )
-                          ],
-                        ),
-                        child: Container(
-                          margin: const EdgeInsets.all(10),
-                          child: Container(
-                            width: 45,
-                            height: 45,
-                            decoration: const BoxDecoration(
-                              shape: BoxShape.circle,
-                              color: Color(0xffFCD8DC),
-                            ),
-                            child: Center(
-                              child: Text(
-                                'S',
-                                style: TextStyle(
-                                  color: Theme.of(context).primaryColor,
-                                  fontWeight: FontWeight.bold,
-                                  fontSize: 16,
-                                ),
+                              const SizedBox(
+                                height: 10,
                               ),
-                            ),
+                              const Text(
+                                "Your sender's profile ",
+                                style: TextStyle(color: Colors.white),
+                              )
+                            ],
                           ),
-                        ),
-                      ),
+                          child: const SAvatarExampleChild(),
+                        )
+                      else
+                        const SAvatarExampleChild(),
                       const Padding(padding: EdgeInsets.only(left: 8)),
                       Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
@@ -430,6 +417,37 @@ class _MailPageState extends State<MailPage> {
                   ),
                 ),
               ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class SAvatarExampleChild extends StatelessWidget {
+  const SAvatarExampleChild({
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.all(10),
+      child: Container(
+        width: 45,
+        height: 45,
+        decoration: const BoxDecoration(
+          shape: BoxShape.circle,
+          color: Color(0xffFCD8DC),
+        ),
+        child: Center(
+          child: Text(
+            'S',
+            style: TextStyle(
+              color: Theme.of(context).primaryColor,
+              fontWeight: FontWeight.bold,
+              fontSize: 16,
             ),
           ),
         ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -59,6 +59,8 @@ class _MailPageState extends State<MailPage> {
   final GlobalKey _six = GlobalKey();
   List<Mail> mails = [];
 
+  final scrollController = ScrollController();
+
   @override
   void initState() {
     super.initState();
@@ -132,6 +134,12 @@ class _MailPageState extends State<MailPage> {
         isUnread: true,
       ),
     ];
+  }
+
+  @override
+  void dispose() {
+    scrollController.dispose();
+    super.dispose();
   }
 
   @override
@@ -244,6 +252,7 @@ class _MailPageState extends State<MailPage> {
             const Padding(padding: EdgeInsets.only(top: 8)),
             Expanded(
               child: ListView.builder(
+                controller: scrollController,
                 physics: const BouncingScrollPhysics(),
                 itemBuilder: (context, index) {
                   if (index == 0) {
@@ -267,6 +276,10 @@ class _MailPageState extends State<MailPage> {
           backgroundColor: Theme.of(context).primaryColor,
           onPressed: () {
             setState(() {
+              /* reset ListView to ensure that the showcased widgets are
+               * currently rendered so the showcased keys are available in the
+               * render tree. */
+              scrollController.jumpTo(0);
               ShowCaseWidget.of(context)!
                   .startShowCase([_one, _two, _three, _four, _five, _six]);
             });

--- a/lib/src/showcase.dart
+++ b/lib/src/showcase.dart
@@ -49,6 +49,7 @@ class Showcase extends StatefulWidget {
   final Widget? container;
   final Color showcaseBackgroundColor;
   final Color textColor;
+  final Widget scrollLoadingWidget;
   final bool showArrow;
   final double? height;
   final double? width;
@@ -79,6 +80,8 @@ class Showcase extends StatefulWidget {
     this.descTextStyle,
     this.showcaseBackgroundColor = Colors.white,
     this.textColor = Colors.black,
+    this.scrollLoadingWidget = const CircularProgressIndicator(
+        valueColor: AlwaysStoppedAnimation(Colors.white)),
     this.showArrow = true,
     this.onTargetClick,
     this.disposeOnTap,
@@ -122,6 +125,8 @@ class Showcase extends StatefulWidget {
     this.descTextStyle,
     this.showcaseBackgroundColor = Colors.white,
     this.textColor = Colors.black,
+    this.scrollLoadingWidget = const CircularProgressIndicator(
+        valueColor: AlwaysStoppedAnimation(Colors.white)),
     this.onTargetClick,
     this.disposeOnTap,
     this.animationDuration = const Duration(milliseconds: 2000),
@@ -140,6 +145,7 @@ class Showcase extends StatefulWidget {
 
 class _ShowcaseState extends State<Showcase> {
   bool _showShowCase = false;
+  bool _isScrollRunning = false;
   Timer? timer;
   GetPosition? position;
 
@@ -164,6 +170,7 @@ class _ShowcaseState extends State<Showcase> {
     });
 
     if (activeStep == widget.key) {
+      _scrollIntoView();
       if (ShowCaseWidget.of(context)!.autoPlay) {
         timer = Timer(
             Duration(
@@ -171,6 +178,22 @@ class _ShowcaseState extends State<Showcase> {
             _nextIfAny);
       }
     }
+  }
+
+  void _scrollIntoView() {
+    WidgetsBinding.instance!.addPostFrameCallback((timeStamp) async {
+      setState(() {
+        _isScrollRunning = true;
+      });
+      await Scrollable.ensureVisible(
+        widget.key.currentContext!,
+        duration: ShowCaseWidget.of(context)!.widget.scrollDuration,
+        alignment: 0.5,
+      );
+      setState(() {
+        _isScrollRunning = false;
+      });
+    });
   }
 
   @override
@@ -238,10 +261,13 @@ class _ShowcaseState extends State<Showcase> {
                 onTap: _nextIfAny,
                 child: ClipPath(
                   clipper: RRectClipper(
-                    area: rectBound,
+                    area: _isScrollRunning ? Rect.zero : rectBound,
                     isCircle: widget.shapeBorder == CircleBorder(),
-                    radius: widget.radius,
-                    overlayPadding: widget.overlayPadding,
+                    radius:
+                        _isScrollRunning ? BorderRadius.zero : widget.radius,
+                    overlayPadding: _isScrollRunning
+                        ? EdgeInsets.zero
+                        : widget.overlayPadding,
                   ),
                   child: blur != 0
                       ? BackdropFilter(
@@ -265,31 +291,34 @@ class _ShowcaseState extends State<Showcase> {
                         ),
                 ),
               ),
-              _TargetWidget(
-                offset: offset,
-                size: size,
-                onTap: _getOnTargetTap,
-                shapeBorder: widget.shapeBorder,
-              ),
-              ToolTipWidget(
-                position: position,
-                offset: offset,
-                screenSize: screenSize,
-                title: widget.title,
-                description: widget.description,
-                titleTextStyle: widget.titleTextStyle,
-                descTextStyle: widget.descTextStyle,
-                container: widget.container,
-                tooltipColor: widget.showcaseBackgroundColor,
-                textColor: widget.textColor,
-                showArrow: widget.showArrow,
-                contentHeight: widget.height,
-                contentWidth: widget.width,
-                onTooltipTap: _getOnTooltipTap,
-                contentPadding: widget.contentPadding,
-                disableAnimation: widget.disableAnimation,
-                animationDuration: widget.animationDuration,
-              ),
+              if (_isScrollRunning) Center(child: widget.scrollLoadingWidget),
+              if (!_isScrollRunning)
+                _TargetWidget(
+                  offset: offset,
+                  size: size,
+                  onTap: _getOnTargetTap,
+                  shapeBorder: widget.shapeBorder,
+                ),
+              if (!_isScrollRunning)
+                ToolTipWidget(
+                  position: position,
+                  offset: offset,
+                  screenSize: screenSize,
+                  title: widget.title,
+                  description: widget.description,
+                  titleTextStyle: widget.titleTextStyle,
+                  descTextStyle: widget.descTextStyle,
+                  container: widget.container,
+                  tooltipColor: widget.showcaseBackgroundColor,
+                  textColor: widget.textColor,
+                  showArrow: widget.showArrow,
+                  contentHeight: widget.height,
+                  contentWidth: widget.width,
+                  onTooltipTap: _getOnTooltipTap,
+                  contentPadding: widget.contentPadding,
+                  disableAnimation: widget.disableAnimation,
+                  animationDuration: widget.animationDuration,
+                ),
             ],
           )
         : SizedBox.shrink();

--- a/lib/src/showcase_widget.dart
+++ b/lib/src/showcase_widget.dart
@@ -34,7 +34,6 @@ class ShowCaseWidget extends StatefulWidget {
   final bool autoPlayLockEnable;
   final Duration scrollDuration;
 
-
   /// Default overlay blur used by showcase. if [Showcase.blurValue]
   /// is not provided.
   ///

--- a/lib/src/showcase_widget.dart
+++ b/lib/src/showcase_widget.dart
@@ -32,6 +32,8 @@ class ShowCaseWidget extends StatefulWidget {
   final bool autoPlay;
   final Duration autoPlayDelay;
   final bool autoPlayLockEnable;
+  final Duration scrollDuration;
+
 
   /// Default overlay blur used by showcase. if [Showcase.blurValue]
   /// is not provided.
@@ -48,6 +50,7 @@ class ShowCaseWidget extends StatefulWidget {
     this.autoPlayDelay = const Duration(milliseconds: 2000),
     this.autoPlayLockEnable = false,
     this.blurValue = 0,
+    this.scrollDuration = const Duration(milliseconds: 300),
   });
 
   static GlobalKey? activeTargetWidget(BuildContext context) {


### PR DESCRIPTION
Users expect that the showcased widget is brought into view in case it is not visible (e.g. #62).

This PR ensures that the current active `Showcase` is in view:

![Peek 2022-02-25 03-39](https://user-images.githubusercontent.com/463840/155643584-b226be86-b392-453e-84db-c50d2d2b784e.gif)

