### PR TITLE
User flutter lints and remove deprecated effective_dart lints.

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: 'package:effective_dart/analysis_options.yaml'
+include: package:flutter_lints/flutter.yaml
 
 analyzer:
   strong-mode:
@@ -19,3 +19,5 @@ linter:
     cancel_subscriptions: true
     close_sinks: true
     avoid_positional_boolean_parameters: false
+    use_super_parameters: true
+    prefer_relative_imports: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  effective_dart: ^1.3.2
+  flutter_lints: ^2.0.1
 
 flutter:


### PR DESCRIPTION
- Replace deprecated `effective_dart` with `flutter_lints`.
- Add 2 lint rules.