### PR TITLE
Feature/tip navigation: New optional navigation options for the Showcase() widget

### DIFF
--- a/lib/src/showcase.dart
+++ b/lib/src/showcase.dart
@@ -63,6 +63,9 @@ class Showcase extends StatefulWidget {
   final VoidCallback? onTargetDoubleTap;
   final VoidCallback? onTargetLongPress;
   final BorderRadius? tipBorderRadius;
+  final bool showForwardBackNav;
+  final bool showTipCountIndex;
+  final bool showEndIcon;
 
   /// if disableDefaultTargetGestures parameter is true
   /// onTargetClick, onTargetDoubleTap, onTargetLongPress and
@@ -107,6 +110,9 @@ class Showcase extends StatefulWidget {
     this.onTargetDoubleTap,
     this.tipBorderRadius,
     this.disableDefaultTargetGestures = false,
+    this.showForwardBackNav = false,
+    this.showTipCountIndex = false,
+    this.showEndIcon = false,
   })  : height = null,
         width = null,
         container = null,
@@ -123,6 +129,9 @@ class Showcase extends StatefulWidget {
                 : (onTargetClick == null ? false : true),
             "onTargetClick is required if you're using disposeOnTap");
 
+  /// Showcase.withWidget allows a widget to be passed to the tooltip instead of just a description String
+  /// It is expected that a user would build their own implementation of forward / back [showForwardBackNav],
+  /// tip count [showTipCountIndex], and end icon [showEndIcon] with this constructor.
   const Showcase.withWidget({
     required this.key,
     required this.child,
@@ -154,6 +163,9 @@ class Showcase extends StatefulWidget {
     this.disableDefaultTargetGestures = false,
   })  : showArrow = false,
         onToolTipClick = null,
+        showForwardBackNav = false,
+        showTipCountIndex = false,
+        showEndIcon = false,
         assert(overlayOpacity >= 0.0 && overlayOpacity <= 1.0,
             "overlay opacity must be between 0 and 1.");
 
@@ -335,6 +347,7 @@ class _ShowcaseState extends State<Showcase> {
                 ),
               if (!_isScrollRunning)
                 ToolTipWidget(
+                  globalKey: widget.key,
                   position: position,
                   offset: offset,
                   screenSize: screenSize,
@@ -354,6 +367,9 @@ class _ShowcaseState extends State<Showcase> {
                       showCaseWidgetState.disableAnimation,
                   animationDuration: widget.animationDuration,
                   borderRadius: widget.tipBorderRadius,
+                  showForwardBackNav: widget.showForwardBackNav,
+                  showTipCountIndex: widget.showTipCountIndex,
+                  showEndIcon: widget.showEndIcon,
                 ),
             ],
           )

--- a/lib/src/tooltip_widget.dart
+++ b/lib/src/tooltip_widget.dart
@@ -394,7 +394,11 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
                             child: Container(
                               padding: const EdgeInsets.all(endIconPaddingAll),
                               color: widget.tooltipColor,
-                              child: const Icon(Icons.close, size: endIconSize),
+                              child: Icon(
+                                Icons.close,
+                                size: endIconSize,
+                                color: widget.textColor,
+                              ),
                             ),
                           ),
                         ),

--- a/lib/src/tooltip_widget.dart
+++ b/lib/src/tooltip_widget.dart
@@ -26,10 +26,12 @@ import 'package:flutter/material.dart';
 
 import 'get_position.dart';
 import 'measure_size.dart';
+import 'tooltip_widget_nav.dart';
 
 const _kDefaultPaddingFromParent = 14.0;
 
 class ToolTipWidget extends StatefulWidget {
+  final GlobalKey globalKey;
   final GetPosition? position;
   final Offset? offset;
   final Size? screenSize;
@@ -48,9 +50,13 @@ class ToolTipWidget extends StatefulWidget {
   final Duration animationDuration;
   final bool disableAnimation;
   final BorderRadius? borderRadius;
+  final bool showForwardBackNav;
+  final bool showTipCountIndex;
+  final bool showEndIcon;
 
   const ToolTipWidget({
     Key? key,
+    required this.globalKey,
     required this.position,
     required this.offset,
     required this.screenSize,
@@ -69,6 +75,9 @@ class ToolTipWidget extends StatefulWidget {
     this.contentPadding = const EdgeInsets.symmetric(vertical: 8),
     required this.disableAnimation,
     required this.borderRadius,
+    required this.showForwardBackNav,
+    required this.showTipCountIndex,
+    required this.showEndIcon,
   }) : super(key: key);
 
   @override
@@ -341,6 +350,15 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
                                                 ),
                                               ),
                                     ),
+                                    TooltipWidgetNav(
+                                      globalKey: widget.globalKey,
+                                      showForwardBackNav:
+                                          widget.showForwardBackNav,
+                                      showTipCountIndex:
+                                          widget.showTipCountIndex,
+                                      showEndIcon: widget.showEndIcon,
+                                      textColor: widget.textColor,
+                                    )
                                   ],
                                 )
                               ],

--- a/lib/src/tooltip_widget.dart
+++ b/lib/src/tooltip_widget.dart
@@ -24,6 +24,7 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 
+import '../showcaseview.dart';
 import 'get_position.dart';
 import 'measure_size.dart';
 import 'tooltip_widget_nav.dart';
@@ -247,6 +248,10 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
 
     const arrowWidth = 18.0;
     const arrowHeight = 9.0;
+    const defaultBorderRadius = 8.0;
+    const endIconPaddingAll = 2.0;
+    const endIconSize = 16.0;
+    const endIconTotalWidth = endIconSize + endIconPaddingAll;
 
     if (widget.container == null) {
       return Positioned(
@@ -306,10 +311,12 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
                       padding: EdgeInsets.only(
                         top: isArrowUp ? arrowHeight - 1 : 0,
                         bottom: isArrowUp ? 0 : arrowHeight - 1,
+                        right:
+                            (widget.showEndIcon) ? (endIconTotalWidth) / 2 : 0,
                       ),
                       child: ClipRRect(
-                        borderRadius:
-                            widget.borderRadius ?? BorderRadius.circular(8.0),
+                        borderRadius: widget.borderRadius ??
+                            BorderRadius.circular(defaultBorderRadius),
                         child: GestureDetector(
                           onTap: widget.onTooltipTap,
                           child: Container(
@@ -356,7 +363,6 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
                                           widget.showForwardBackNav,
                                       showTipCountIndex:
                                           widget.showTipCountIndex,
-                                      showEndIcon: widget.showEndIcon,
                                       textColor: widget.textColor,
                                     )
                                   ],
@@ -367,6 +373,32 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
                         ),
                       ),
                     ),
+                    if (widget.showEndIcon)
+                      Positioned(
+                        right: 0,
+                        top: (isArrowUp) ? arrowHeight - 1 : 0,
+                        child: GestureDetector(
+                          behavior: HitTestBehavior.translucent,
+                          onTap: () {
+                            debugPrint("End");
+                            ShowCaseWidget.of(widget.globalKey.currentContext!)
+                                .dismiss();
+                          },
+                          child: ClipRRect(
+                            borderRadius: const BorderRadius.only(
+                              topLeft: Radius.zero,
+                              topRight: Radius.circular(50),
+                              bottomRight: Radius.circular(50),
+                              bottomLeft: Radius.circular(50),
+                            ),
+                            child: Container(
+                              padding: const EdgeInsets.all(endIconPaddingAll),
+                              color: widget.tooltipColor,
+                              child: const Icon(Icons.close, size: endIconSize),
+                            ),
+                          ),
+                        ),
+                      ),
                   ],
                 ),
               ),

--- a/lib/src/tooltip_widget.dart
+++ b/lib/src/tooltip_widget.dart
@@ -172,7 +172,6 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
 
   double? _getRight() {
     if (widget.position != null) {
-      debugPrint("This condition");
       var rightPosition = widget.position!.getCenter() + (tooltipWidth * 0.5);
 
       // Accommodate end icon offset width if enabled
@@ -402,7 +401,6 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
                               child: GestureDetector(
                                 behavior: HitTestBehavior.translucent,
                                 onTap: () {
-                                  debugPrint("End");
                                   ShowCaseWidget.of(
                                           widget.globalKey.currentContext!)
                                       .dismiss();

--- a/lib/src/tooltip_widget.dart
+++ b/lib/src/tooltip_widget.dart
@@ -237,9 +237,6 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
 
   @override
   Widget build(BuildContext context) {
-    debugPrint("Left: ${_getLeft()}");
-    debugPrint("Right: ${_getRight()}");
-
     position = widget.offset;
     final contentOrientation = findPositionForContent(position!);
     final contentOffsetMultiplier = contentOrientation == "BELOW" ? 1.0 : -1.0;

--- a/lib/src/tooltip_widget_nav.dart
+++ b/lib/src/tooltip_widget_nav.dart
@@ -58,7 +58,12 @@ class TooltipWidgetNav extends StatelessWidget {
                 const SizedBox(width: 4.0),
                 Padding(
                   padding: const EdgeInsets.only(top: 4.0),
-                  child: Text("${activeWidgetId + 1} / ${ids.length}"),
+                  child: Text(
+                    "${activeWidgetId + 1} / ${ids.length}",
+                    style: TextStyle(
+                      color: textColor,
+                    ),
+                  ),
                 ),
                 const SizedBox(width: 4.0),
               ],

--- a/lib/src/tooltip_widget_nav.dart
+++ b/lib/src/tooltip_widget_nav.dart
@@ -8,14 +8,12 @@ class TooltipWidgetNav extends StatelessWidget {
   final GlobalKey globalKey;
   final bool showForwardBackNav;
   final bool showTipCountIndex;
-  final bool showEndIcon;
   final Color? textColor;
   const TooltipWidgetNav({
     Key? key,
     required this.globalKey,
     required this.showForwardBackNav,
     required this.showTipCountIndex,
-    required this.showEndIcon,
     required this.textColor,
   }) : super(key: key);
 
@@ -34,34 +32,48 @@ class TooltipWidgetNav extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               if (showForwardBackNav)
-                IconButton(
+                GestureDetector(
+                  behavior: HitTestBehavior.translucent,
+
                   // Disable if activeWidgetId (index) == 0
-                  onPressed: (isFirstTip)
+                  onTap: (isFirstTip)
                       ? null
                       : () {
                           ShowCaseWidget.of(globalKey.currentContext!)
                               .previous();
                         },
-                  icon: Icon(
-                    Icons.keyboard_arrow_left,
-                    color: (isFirstTip) ? null : textColor,
+                  child: Padding(
+                    padding: const EdgeInsets.only(right: 8.0, top: 4.0),
+                    child: Icon(
+                      Icons.keyboard_arrow_left,
+                      color: (isFirstTip)
+                          ? textColor?.withOpacity(0.3) ?? Colors.black26
+                          : textColor,
+                    ),
                   ),
                 ),
               if (showTipCountIndex &&
                   ids != null &&
                   activeWidgetId != null) ...[
                 const SizedBox(width: 4.0),
-                Text("${activeWidgetId + 1} / ${ids.length}"),
+                Padding(
+                  padding: const EdgeInsets.only(top: 4.0),
+                  child: Text("${activeWidgetId + 1} / ${ids.length}"),
+                ),
                 const SizedBox(width: 4.0),
               ],
               if (showForwardBackNav)
-                IconButton(
-                  onPressed: () {
+                GestureDetector(
+                  behavior: HitTestBehavior.translucent,
+                  onTap: () {
                     ShowCaseWidget.of(globalKey.currentContext!).next();
                   },
-                  icon: Icon(
-                    Icons.keyboard_arrow_right,
-                    color: textColor,
+                  child: Padding(
+                    padding: const EdgeInsets.only(left: 8.0, top: 4.0),
+                    child: Icon(
+                      Icons.keyboard_arrow_right,
+                      color: textColor,
+                    ),
                   ),
                 ),
             ],

--- a/lib/src/tooltip_widget_nav.dart
+++ b/lib/src/tooltip_widget_nav.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+
+import '../showcaseview.dart';
+
+/// Tooltip Widget Nav
+/// Shows tooltip navigation and index / count elements if the conditions are indicated.
+class TooltipWidgetNav extends StatelessWidget {
+  final GlobalKey globalKey;
+  final bool showForwardBackNav;
+  final bool showTipCountIndex;
+  final bool showEndIcon;
+  final Color? textColor;
+  const TooltipWidgetNav({
+    Key? key,
+    required this.globalKey,
+    required this.showForwardBackNav,
+    required this.showTipCountIndex,
+    required this.showEndIcon,
+    required this.textColor,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    var ids = ShowCaseWidget.of(globalKey.currentContext!).ids;
+    var activeWidgetId =
+        ShowCaseWidget.of(globalKey.currentContext!).activeWidgetId;
+    bool isFirstTip = activeWidgetId == 0;
+
+    if (showForwardBackNav || showTipCountIndex) {
+      return Column(
+        children: [
+          // const SizedBox(height: 4.0),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              if (showForwardBackNav)
+                IconButton(
+                  // Disable if activeWidgetId (index) == 0
+                  onPressed: (isFirstTip)
+                      ? null
+                      : () {
+                          ShowCaseWidget.of(globalKey.currentContext!)
+                              .previous();
+                        },
+                  icon: Icon(
+                    Icons.keyboard_arrow_left,
+                    color: (isFirstTip) ? null : textColor,
+                  ),
+                ),
+              if (showTipCountIndex &&
+                  ids != null &&
+                  activeWidgetId != null) ...[
+                const SizedBox(width: 4.0),
+                Text("${activeWidgetId + 1} / ${ids.length}"),
+                const SizedBox(width: 4.0),
+              ],
+              if (showForwardBackNav)
+                IconButton(
+                  onPressed: () {
+                    ShowCaseWidget.of(globalKey.currentContext!).next();
+                  },
+                  icon: Icon(
+                    Icons.keyboard_arrow_right,
+                    color: textColor,
+                  ),
+                ),
+            ],
+          ),
+        ],
+      );
+    } else {
+      return const SizedBox();
+    }
+  }
+}


### PR DESCRIPTION
New feature to allow the developer to optionally enable the following features for each Showcase() widget:

- Navigation icons (forward / back)
- Counter / Pager to show where in the tutorial the user is
- End icon that allows the user to end the tutorial early

Features are off by default. Parameters are optional to avoid breaking old instances.

**Example Photo**
<img width="303" alt="example-showcase-with-nav" src="https://user-images.githubusercontent.com/3958274/192395173-3dbf5b5c-ffe7-4188-b135-faa608965991.png">

```dart
Showcase(
    key: _showcaseSettings,
    showTipCountIndex: true,
    showForwardBackNav: true,
    showEndIcon: true,
    description: ref.read(getMachineNavigationTipsProvider).getTipContent('settings_top'),
    child: Text(AppLocalizations.of(context)!.screenTitlesSettings, style: kTextStyleHeading2),
)
```

A developer could extend the Showcase() widget to pass their own default values.
