### PR TITLE
Take in account view insets (such as keyboard)

### DIFF
--- a/lib/src/tooltip_widget.dart
+++ b/lib/src/tooltip_widget.dart
@@ -94,7 +94,11 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
     final bottomPosition =
         position.dy + ((widget.position?.getHeight() ?? 0) / 2);
     final topPosition = position.dy - ((widget.position?.getHeight() ?? 0) / 2);
-    return ((widget.screenSize?.height ?? MediaQuery.of(context).size.height) -
+    
+    EdgeInsets viewInsets = EdgeInsets.fromWindowPadding(WidgetsBinding.instance.window.viewInsets, WidgetsBinding.instance.window.devicePixelRatio);
+    double actualVisibleScreenHeight = (widget.screenSize?.height ?? MediaQuery.of(context).size.height) - viewInsets.bottom;
+    
+    return (actualVisibleScreenHeight -
                 bottomPosition) <=
             height &&
         topPosition >= height;


### PR DESCRIPTION
Take in account the view insets of the device, such as the keyboard that is up, so that we can correctly determine if the widget should be on top or below. If you're trying to highlight something that is at the bottom of the screen and the keyboard is up, it will try to render it below the widget, which would be under the keyboard.

By taking in account view insets we can assure that widgets that are sticky to the bottom get correctly highlighted when the keyboard is up.

To test this all you need to do is make a widget sticky to the bottom of your screen, summon the keyboard and then showcase the sticky widget. You'll see that everything is blacked out except the sticky widget, but the arrow and text message will be invisible as it's below the keyboard.