### PR TITLE
fix: position/size on flutter web

### DIFF
--- a/lib/src/get_position.dart
+++ b/lib/src/get_position.dart
@@ -25,42 +25,17 @@ import 'package:flutter/material.dart';
 class GetPosition {
   final GlobalKey? key;
   final EdgeInsets padding;
-  final double? screenWidth;
-  final double? screenHeight;
 
-  GetPosition(
-      {this.key,
-      this.padding = EdgeInsets.zero,
-      this.screenWidth,
-      this.screenHeight});
-
-  Rect getRect() {
-    final box = key!.currentContext!.findRenderObject() as RenderBox;
-
-    var boxOffset = box.localToGlobal(const Offset(0.0, 0.0));
-    if (boxOffset.dx.isNaN || boxOffset.dy.isNaN) {
-      return const Rect.fromLTRB(0, 0, 0, 0);
-    }
-    final topLeft = box.size.topLeft(boxOffset);
-    final bottomRight = box.size.bottomRight(boxOffset);
-
-    final rect = Rect.fromLTRB(
-      topLeft.dx - padding.left < 0 ? 0 : topLeft.dx - padding.left,
-      topLeft.dy - padding.top < 0 ? 0 : topLeft.dy - padding.top,
-      bottomRight.dx + padding.right > screenWidth!
-          ? screenWidth!
-          : bottomRight.dx + padding.right,
-      bottomRight.dy + padding.bottom > screenHeight!
-          ? screenHeight!
-          : bottomRight.dy + padding.bottom,
-    );
-    return rect;
-  }
+  GetPosition({
+    this.key,
+    this.padding = EdgeInsets.zero,
+  });
 
   ///Get the bottom position of the widget
   double getBottom() {
     final box = key!.currentContext!.findRenderObject() as RenderBox;
-    final boxOffset = box.localToGlobal(const Offset(0.0, 0.0));
+    final boxOffset =
+        box.localToGlobal(-(getMaterialAppOffset(key!.currentContext!)));
     if (boxOffset.dy.isNaN) return padding.bottom;
     final bottomRight = box.size.bottomRight(boxOffset);
     return bottomRight.dy + padding.bottom;
@@ -69,7 +44,8 @@ class GetPosition {
   ///Get the top position of the widget
   double getTop() {
     final box = key!.currentContext!.findRenderObject() as RenderBox;
-    final boxOffset = box.localToGlobal(const Offset(0.0, 0.0));
+    final boxOffset =
+        box.localToGlobal(-(getMaterialAppOffset(key!.currentContext!)));
     if (boxOffset.dy.isNaN) return 0 - padding.top;
     final topLeft = box.size.topLeft(boxOffset);
     return topLeft.dy - padding.top;
@@ -78,7 +54,8 @@ class GetPosition {
   ///Get the left position of the widget
   double getLeft() {
     final box = key!.currentContext!.findRenderObject() as RenderBox;
-    final boxOffset = box.localToGlobal(const Offset(0.0, 0.0));
+    final boxOffset =
+        box.localToGlobal(-(getMaterialAppOffset(key!.currentContext!)));
     if (boxOffset.dx.isNaN) return 0 - padding.left;
     final topLeft = box.size.topLeft(boxOffset);
     return topLeft.dx - padding.left;
@@ -87,10 +64,10 @@ class GetPosition {
   ///Get the right position of the widget
   double getRight() {
     final box = key!.currentContext!.findRenderObject() as RenderBox;
-    final boxOffset = box.localToGlobal(const Offset(0.0, 0.0));
+    final boxOffset =
+        box.localToGlobal(-(getMaterialAppOffset(key!.currentContext!)));
     if (boxOffset.dx.isNaN) return padding.right;
-    final bottomRight =
-        box.size.bottomRight(box.localToGlobal(const Offset(0.0, 0.0)));
+    final bottomRight = box.size.bottomRight(boxOffset);
     return bottomRight.dx + padding.right;
   }
 
@@ -104,5 +81,20 @@ class GetPosition {
 
   double getCenter() {
     return (getLeft() + getRight()) / 2;
+  }
+
+  // Gets the position of the ancestor MaterialApp. Better alternative to assuming Offset.zero in web context when calculating LTRB
+  static Offset getMaterialAppOffset(BuildContext context) {
+    final state = context.findAncestorStateOfType<State<MaterialApp>>()!;
+    if (!state.mounted) return Offset.zero;
+    RenderBox box = state.context.findRenderObject() as RenderBox;
+    return box.localToGlobal(Offset.zero);
+  }
+
+  // Gets the size of the ancestor MaterialApp. Better alternative to MediaQuery.of(context).size in web context
+  static Size getMaterialAppSize(BuildContext context) {
+    final state = context.findAncestorStateOfType<State<MaterialApp>>()!;
+    RenderBox box = state.context.findRenderObject() as RenderBox;
+    return box.size;
   }
 }

--- a/lib/src/layout_overlays.dart
+++ b/lib/src/layout_overlays.dart
@@ -24,6 +24,7 @@ import 'package:flutter/material.dart';
 
 import 'extension.dart';
 import 'showcase_widget.dart';
+import 'get_position.dart';
 
 /// Displays an overlay Widget anchored directly above the center of this
 /// [AnchoredOverlay].
@@ -63,10 +64,11 @@ class AnchoredOverlay extends StatelessWidget {
             // To calculate the "anchor" point we grab the render box of
             // our parent Container and then we find the center of that box.
             final box = context.findRenderObject() as RenderBox;
+            final materialAppOffset = GetPosition.getMaterialAppOffset(context);
             final topLeft =
-                box.size.topLeft(box.localToGlobal(const Offset(0.0, 0.0)));
+                box.size.topLeft(box.localToGlobal(-materialAppOffset));
             final bottomRight =
-                box.size.bottomRight(box.localToGlobal(const Offset(0.0, 0.0)));
+                box.size.bottomRight(box.localToGlobal(-materialAppOffset));
             Rect anchorBounds;
             anchorBounds = (topLeft.dx.isNaN ||
                     topLeft.dy.isNaN ||

--- a/lib/src/showcase.dart
+++ b/lib/src/showcase.dart
@@ -339,8 +339,6 @@ class _ShowcaseState extends State<Showcase> {
     position ??= GetPosition(
       key: widget.key,
       padding: widget.targetPadding,
-      screenWidth: MediaQuery.of(context).size.width,
-      screenHeight: MediaQuery.of(context).size.height,
     );
     showOverlay();
   }
@@ -386,12 +384,10 @@ class _ShowcaseState extends State<Showcase> {
   Widget build(BuildContext context) {
     return AnchoredOverlay(
       overlayBuilder: (context, rectBound, offset) {
-        final size = MediaQuery.of(context).size;
+        final size = GetPosition.getMaterialAppSize(context);
         position = GetPosition(
           key: widget.key,
           padding: widget.targetPadding,
-          screenWidth: size.width,
-          screenHeight: size.height,
         );
         return buildOverlayOnTarget(offset, rectBound.size, rectBound, size);
       },
@@ -480,8 +476,10 @@ class _ShowcaseState extends State<Showcase> {
                       ? BackdropFilter(
                           filter: ImageFilter.blur(sigmaX: blur, sigmaY: blur),
                           child: Container(
-                            width: MediaQuery.of(context).size.width,
-                            height: MediaQuery.of(context).size.height,
+                            width:
+                                GetPosition.getMaterialAppSize(context).width,
+                            height:
+                                GetPosition.getMaterialAppSize(context).height,
                             decoration: BoxDecoration(
                               color: widget.overlayColor
                                   .withOpacity(widget.overlayOpacity),
@@ -489,8 +487,9 @@ class _ShowcaseState extends State<Showcase> {
                           ),
                         )
                       : Container(
-                          width: MediaQuery.of(context).size.width,
-                          height: MediaQuery.of(context).size.height,
+                          width: GetPosition.getMaterialAppSize(context).width,
+                          height:
+                              GetPosition.getMaterialAppSize(context).height,
                           decoration: BoxDecoration(
                             color: widget.overlayColor
                                 .withOpacity(widget.overlayOpacity),

--- a/lib/src/tooltip_widget.dart
+++ b/lib/src/tooltip_widget.dart
@@ -110,7 +110,8 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
     final bottomPosition =
         position.dy + ((widget.position?.getHeight() ?? 0) / 2);
     final topPosition = position.dy - ((widget.position?.getHeight() ?? 0) / 2);
-    return ((widget.screenSize?.height ?? MediaQuery.of(context).size.height) -
+    return ((widget.screenSize?.height ??
+                    GetPosition.getMaterialAppSize(context).height) -
                 bottomPosition) <=
             height &&
         topPosition >= height;
@@ -158,7 +159,8 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
       final width =
           widget.container != null ? _customContainerWidth.value : tooltipWidth;
       double leftPositionValue = widget.position!.getCenter() - (width * 0.5);
-      if ((leftPositionValue + width) > MediaQuery.of(context).size.width) {
+      if ((leftPositionValue + width) >
+          GetPosition.getMaterialAppSize(context).width) {
         return null;
       } else if ((leftPositionValue) < _kDefaultPaddingFromParent) {
         return _kDefaultPaddingFromParent;
@@ -175,10 +177,12 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
           widget.container != null ? _customContainerWidth.value : tooltipWidth;
 
       if (_getLeft() == null ||
-          ((_getLeft() ?? 0) + width) > MediaQuery.of(context).size.width) {
+          ((_getLeft() ?? 0) + width) >
+              GetPosition.getMaterialAppSize(context).width) {
         final rightPosition = widget.position!.getCenter() + (width * 0.5);
 
-        return (rightPosition + width) > MediaQuery.of(context).size.width
+        return (rightPosition + width) >
+                GetPosition.getMaterialAppSize(context).width
             ? _kDefaultPaddingFromParent
             : null;
       } else {
@@ -203,7 +207,8 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
         ? 0
         : (widget.position!.getCenter() - (_getLeft() ?? 0));
     var right = _getLeft() == null
-        ? (MediaQuery.of(context).size.width - widget.position!.getCenter()) -
+        ? (GetPosition.getMaterialAppSize(context).width -
+                widget.position!.getCenter()) -
             (_getRight() ?? 0)
         : 0;
     final containerWidth =
@@ -219,7 +224,8 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
   double _getAlignmentY() {
     var dy = isArrowUp
         ? -1.0
-        : (MediaQuery.of(context).size.height / 2) < widget.position!.getTop()
+        : (GetPosition.getMaterialAppSize(context).height / 2) <
+                widget.position!.getTop()
             ? -1.0
             : 1.0;
     return dy;
@@ -373,7 +379,7 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
                                   (arrowWidth / 2) -
                                   (_getLeft() ?? 0)),
                           right: _getLeft() == null
-                              ? (MediaQuery.of(context).size.width -
+                              ? (GetPosition.getMaterialAppSize(context).width -
                                       widget.position!.getCenter()) -
                                   (_getRight() ?? 0) -
                                   (arrowWidth / 2)


### PR DESCRIPTION
# Description

- Subtracting the offset of MaterialApp when calculating LTRB
- Using the size of MaterialApp instead of MediaQuery.of(context).size


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [- ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require ShowCaseView users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->
Fixes #308 

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
