### PR TITLE
fix: Use maybeOf(context) instead of of(context) in order to check null value

### DIFF
--- a/lib/src/layout_overlays.dart
+++ b/lib/src/layout_overlays.dart
@@ -173,10 +173,10 @@ class _OverlayBuilderState extends State<OverlayBuilder> {
   void addToOverlay(OverlayEntry overlayEntry) async {
     final showCaseContext = ShowCaseWidget.of(context).context;
     if (mounted) {
-      if (Overlay.of(showCaseContext) != null) {
+      if (Overlay.maybeOf(showCaseContext) != null) {
         Overlay.of(showCaseContext)!.insert(overlayEntry);
       } else {
-        if (Overlay.of(context) != null) {
+        if (Overlay.maybeOf(context) != null) {
           Overlay.of(context)!.insert(overlayEntry);
         }
       }


### PR DESCRIPTION
# Description
Using the new flutter version 3.7 and above the call to Overlay.of(showCaseContext) throws an hard error on null value which breaks the previous behaviour. Instead make use of the maybeOf which returns null if no value is given.

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require ShowCaseView users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
Closes [#330](https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/issues/330)
