### PR TITLE
Fix showcase target overlay at wrong position

### DIFF
--- a/lib/src/showcase.dart
+++ b/lib/src/showcase.dart
@@ -584,12 +584,12 @@ class _TargetWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Positioned(
-      top: offset.dy,
-      left: offset.dx,
+      top: offset.dy - (size == null ? 0 : size!.height / 2),
+      left: offset.dx - (size == null ? 0 : size!.width / 2),
       child: IgnorePointer(
         ignoring: disableDefaultChildGestures,
         child: FractionalTranslation(
-          translation: const Offset(-0.5, -0.5),
+          translation: size == null ? const Offset(-0.5, -0.5) : Offset.zero,
           child: GestureDetector(
             onTap: onTap,
             onLongPress: onLongPress,


### PR DESCRIPTION
# Description

Doing some debugging I saw that the target overlay was being laid out starting from the center of the target. I fixed it simply by subtracting half the size from the offset.

I kept the `FractionalTranslation` there anyway because I didn't want to break anything, but now it only translates when `size` is null.

Fixes #346 Dont respond to any clicks in target