### PR TITLE
feat: ✨ Add onBarrierTapped and overlay context backward compatibility

### DIFF
--- a/lib/src/enum.dart
+++ b/lib/src/enum.dart
@@ -20,4 +20,4 @@
  * SOFTWARE.
  */
 
-enum TooltipPosition { top, bottom }
+enum ShowCaseTooltipPosition { top, bottom }

--- a/lib/src/layout_overlays.dart
+++ b/lib/src/layout_overlays.dart
@@ -173,10 +173,10 @@ class _OverlayBuilderState extends State<OverlayBuilder> {
   void addToOverlay(OverlayEntry overlayEntry) async {
     if (mounted) {
       final showCaseContext = ShowCaseWidget.of(context).context;
-      if (Overlay.maybeOf(showCaseContext) != null) {
-        Overlay.of(showCaseContext).insert(overlayEntry);
-      } else if (Overlay.maybeOf(context) != null) {
-        Overlay.of(context).insert(overlayEntry);
+      if ( Overlay.of(showCaseContext) != null) {
+        Overlay.of(showCaseContext)!.insert(overlayEntry);
+      } else if (Overlay.of(context) != null) {
+        Overlay.of(context)!.insert(overlayEntry);
       }
     }
   }

--- a/lib/src/showcase.dart
+++ b/lib/src/showcase.dart
@@ -480,7 +480,7 @@ class _ShowcaseState extends State<Showcase> {
           onTap: () {
             if (!showCaseWidgetState.disableBarrierInteraction) {
               if(widget.onBarrierTapped !=null){
-                widget.onBarrierTapped.call()
+                widget.onBarrierTapped!.call();
               }else{
                 _nextIfAny();
               }

--- a/lib/src/showcase.dart
+++ b/lib/src/showcase.dart
@@ -224,7 +224,7 @@ class Showcase extends StatefulWidget {
   /// Defines vertical position of tooltip respective to Target widget
   ///
   /// Defaults to adaptive into available space.
-  final TooltipPosition? tooltipPosition;
+  final ShowCaseTooltipPosition? tooltipPosition;
 
   /// Provides padding around the title. Default padding is zero.
   final EdgeInsets? titlePadding;

--- a/lib/src/showcase.dart
+++ b/lib/src/showcase.dart
@@ -479,7 +479,11 @@ class _ShowcaseState extends State<Showcase> {
         GestureDetector(
           onTap: () {
             if (!showCaseWidgetState.disableBarrierInteraction) {
-                widget.onBarrierTapped?.call()??_nextIfAny();
+              if(widget.onBarrierTapped !=null){
+                widget.onBarrierTapped.call()
+              }else{
+                _nextIfAny();
+              }
             }
           },
           child: ClipPath(

--- a/lib/src/showcase.dart
+++ b/lib/src/showcase.dart
@@ -231,6 +231,9 @@ class Showcase extends StatefulWidget {
 
   /// Provides padding around the description. Default padding is zero.
   final EdgeInsets? descriptionPadding;
+  
+  /// Triggered when barrier tapped
+  final VoidCallback? onBarrierTapped;
 
   const Showcase({
     required this.key,
@@ -273,6 +276,7 @@ class Showcase extends StatefulWidget {
     this.tooltipPosition,
     this.titlePadding,
     this.descriptionPadding,
+    this.onBarrierTapped
   })  : height = null,
         width = null,
         container = null,
@@ -309,6 +313,7 @@ class Showcase extends StatefulWidget {
     this.onTargetDoubleTap,
     this.disableDefaultTargetGestures = false,
     this.tooltipPosition,
+    this.onBarrierTapped
   })  : showArrow = false,
         onToolTipClick = null,
         scaleAnimationDuration = const Duration(milliseconds: 300),
@@ -474,7 +479,7 @@ class _ShowcaseState extends State<Showcase> {
         GestureDetector(
           onTap: () {
             if (!showCaseWidgetState.disableBarrierInteraction) {
-              _nextIfAny();
+                widget.onBarrierTapped?.call()??_nextIfAny();
             }
           },
           child: ClipPath(

--- a/lib/src/tooltip_widget.dart
+++ b/lib/src/tooltip_widget.dart
@@ -56,7 +56,7 @@ class ToolTipWidget extends StatefulWidget {
   final Curve scaleAnimationCurve;
   final Alignment? scaleAnimationAlignment;
   final bool isTooltipDismissed;
-  final TooltipPosition? tooltipPosition;
+  final ShowCaseTooltipPosition? tooltipPosition;
   final EdgeInsets? titlePadding;
   final EdgeInsets? descriptionPadding;
 

--- a/lib/src/tooltip_widget.dart
+++ b/lib/src/tooltip_widget.dart
@@ -111,7 +111,7 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
   double tooltipScreenEdgePadding = 20;
   double tooltipTextPadding = 15;
 
-  TooltipPosition findPositionForContent(Offset position) {
+  ShowCaseTooltipPosition findPositionForContent(Offset position) {
     var height = 120.0;
     height = widget.contentHeight ?? height;
     final bottomPosition =
@@ -128,8 +128,8 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
         (actualVisibleScreenHeight - bottomPosition) >= height;
     return widget.tooltipPosition ??
         (hasSpaceInTop && !hasSpaceInBottom
-            ? TooltipPosition.top
-            : TooltipPosition.bottom);
+            ? ShowCaseTooltipPosition.top
+            : ShowCaseTooltipPosition.bottom);
   }
 
   void _getTooltipWidth() {
@@ -322,7 +322,7 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
     position = widget.offset;
     final contentOrientation = findPositionForContent(position!);
     final contentOffsetMultiplier =
-        contentOrientation == TooltipPosition.bottom ? 1.0 : -1.0;
+        contentOrientation == ShowCaseTooltipPosition.bottom ? 1.0 : -1.0;
     isArrowUp = contentOffsetMultiplier == 1.0;
 
     final contentY = isArrowUp


### PR DESCRIPTION
# Description
- ✨ Add onBarrierTapped
- Add overlay context backward compatibility to flutter older than 3.3.7
- Avoid conflicts with `'package:syncfusion_flutter_charts/charts.dart';`

## Checklist

- [X] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [X] I have followed the [Contributor Guide] when preparing my PR.
- [X] I have updated/added tests for ALL new/updated/fixed functionality.
- [X] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [X] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
- [ ] Yes, this PR is a breaking change.
- [X] No, this PR is not a breaking change.


## Related Issues
Closes  #350 

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
