### PR TITLE
fix: child-constructor-invocation

### DIFF
--- a/lib/src/showcase.dart
+++ b/lib/src/showcase.dart
@@ -234,10 +234,10 @@ class Showcase extends StatefulWidget {
 
   const Showcase({
     required this.key,
+    required this.description,
     required this.child,
     this.title,
     this.titleAlignment = TextAlign.start,
-    required this.description,
     this.descriptionAlignment = TextAlign.start,
     this.targetShapeBorder = const RoundedRectangleBorder(
       borderRadius: BorderRadius.all(Radius.circular(8)),
@@ -285,10 +285,10 @@ class Showcase extends StatefulWidget {
 
   const Showcase.withWidget({
     required this.key,
-    required this.child,
-    required this.container,
     required this.height,
     required this.width,
+    required this.container,
+    required this.child,
     this.targetShapeBorder = const RoundedRectangleBorder(
       borderRadius: BorderRadius.all(
         Radius.circular(8),


### PR DESCRIPTION
 # Description

fixed child-constructor-invocation issue caused on  
>sdk: '>=2.19.3 <3.0.0' with flutter_lints: ^2.0.0.

As for the example code, it also marches the format.

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require ShowCaseView users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
