### PR TITLE
fix: target position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [2.0.4] (Unreleased)
+- Improved internal `findRenderObject` calls.
+
 ## [2.0.3]
 - Feature [#148](https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/issues/148) - Add feasibility to add `textDirection` of `title` and `description`.
 - Feature [#272](https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/issues/272) - Add barrier click callback.

--- a/lib/src/get_position.dart
+++ b/lib/src/get_position.dart
@@ -23,36 +23,49 @@
 import 'package:flutter/material.dart';
 
 class GetPosition {
-  final GlobalKey? key;
-  final EdgeInsets padding;
-  final double? screenWidth;
-  final double? screenHeight;
-
   GetPosition({
-    this.key,
+    required this.key,
+    required this.screenWidth,
+    required this.screenHeight,
     this.padding = EdgeInsets.zero,
-    this.screenWidth,
-    this.screenHeight,
-  });
+  }) {
+    getRenderBox();
+  }
+
+  final GlobalKey key;
+  final EdgeInsets padding;
+  final double screenWidth;
+  final double screenHeight;
+
+  late final RenderBox? _box;
+  late final Offset? _boxOffset;
+
+  void getRenderBox() {
+    var renderBox = key.currentContext?.findRenderObject() as RenderBox?;
+    if (renderBox != null) {
+      _box = renderBox;
+      _boxOffset = _box?.localToGlobal(Offset.zero);
+    }
+  }
 
   Rect getRect() {
-    final box = key!.currentContext!.findRenderObject() as RenderBox;
-
-    var boxOffset = box.localToGlobal(const Offset(0.0, 0.0));
-    if (boxOffset.dx.isNaN || boxOffset.dy.isNaN) {
-      return const Rect.fromLTRB(0, 0, 0, 0);
+    if (_box == null ||
+        _boxOffset == null ||
+        (_boxOffset?.dx.isNaN ?? true) ||
+        (_boxOffset?.dy.isNaN ?? true)) {
+      return Rect.zero;
     }
-    final topLeft = box.size.topLeft(boxOffset);
-    final bottomRight = box.size.bottomRight(boxOffset);
+    final topLeft = _box!.size.topLeft(_boxOffset!);
+    final bottomRight = _box!.size.bottomRight(_boxOffset!);
 
     final rect = Rect.fromLTRB(
       topLeft.dx - padding.left < 0 ? 0 : topLeft.dx - padding.left,
       topLeft.dy - padding.top < 0 ? 0 : topLeft.dy - padding.top,
-      bottomRight.dx + padding.right > screenWidth!
-          ? screenWidth!
+      bottomRight.dx + padding.right > screenWidth
+          ? screenWidth
           : bottomRight.dx + padding.right,
-      bottomRight.dy + padding.bottom > screenHeight!
-          ? screenHeight!
+      bottomRight.dy + padding.bottom > screenHeight
+          ? screenHeight
           : bottomRight.dy + padding.bottom,
     );
     return rect;
@@ -60,38 +73,37 @@ class GetPosition {
 
   ///Get the bottom position of the widget
   double getBottom() {
-    final box = key!.currentContext!.findRenderObject() as RenderBox;
-    final boxOffset = box.localToGlobal(const Offset(0.0, 0.0));
-    if (boxOffset.dy.isNaN) return padding.bottom;
-    final bottomRight = box.size.bottomRight(boxOffset);
+    if (_box == null || _boxOffset == null || (_boxOffset?.dy.isNaN ?? true)) {
+      return padding.bottom;
+    }
+    final bottomRight = _box!.size.bottomRight(_boxOffset!);
     return bottomRight.dy + padding.bottom;
   }
 
   ///Get the top position of the widget
   double getTop() {
-    final box = key!.currentContext!.findRenderObject() as RenderBox;
-    final boxOffset = box.localToGlobal(const Offset(0.0, 0.0));
-    if (boxOffset.dy.isNaN) return 0 - padding.top;
-    final topLeft = box.size.topLeft(boxOffset);
+    if (_box == null || _boxOffset == null || (_boxOffset?.dy.isNaN ?? true)) {
+      return 0 - padding.top;
+    }
+    final topLeft = _box!.size.topLeft(_boxOffset!);
     return topLeft.dy - padding.top;
   }
 
   ///Get the left position of the widget
   double getLeft() {
-    final box = key!.currentContext!.findRenderObject() as RenderBox;
-    final boxOffset = box.localToGlobal(const Offset(0.0, 0.0));
-    if (boxOffset.dx.isNaN) return 0 - padding.left;
-    final topLeft = box.size.topLeft(boxOffset);
+    if (_box == null || _boxOffset == null || (_boxOffset?.dx.isNaN ?? true)) {
+      return 0 - padding.left;
+    }
+    final topLeft = _box!.size.topLeft(_boxOffset!);
     return topLeft.dx - padding.left;
   }
 
   ///Get the right position of the widget
   double getRight() {
-    final box = key!.currentContext!.findRenderObject() as RenderBox;
-    final boxOffset = box.localToGlobal(const Offset(0.0, 0.0));
-    if (boxOffset.dx.isNaN) return padding.right;
-    final bottomRight =
-        box.size.bottomRight(box.localToGlobal(const Offset(0.0, 0.0)));
+    if (_box == null || _boxOffset == null || (_boxOffset?.dx.isNaN ?? true)) {
+      return padding.right;
+    }
+    final bottomRight = _box!.size.bottomRight(_boxOffset!);
     return bottomRight.dx + padding.right;
   }
 

--- a/lib/src/get_position.dart
+++ b/lib/src/get_position.dart
@@ -44,7 +44,11 @@ class GetPosition {
     var renderBox = key.currentContext?.findRenderObject() as RenderBox?;
     if (renderBox != null) {
       _box = renderBox;
-      _boxOffset = _box?.localToGlobal(Offset.zero);
+      final offset = _box?.globalToLocal(Offset.zero);
+      // final offset = _box?.localToGlobal(Offset.zero);
+      if (offset != null) {
+        _boxOffset = Offset(offset.dx.abs(), offset.dy.abs());
+      }
     }
   }
 

--- a/lib/src/get_position.dart
+++ b/lib/src/get_position.dart
@@ -45,7 +45,6 @@ class GetPosition {
     if (renderBox != null) {
       _box = renderBox;
       final offset = _box?.globalToLocal(Offset.zero);
-      // final offset = _box?.localToGlobal(Offset.zero);
       if (offset != null) {
         _boxOffset = Offset(offset.dx.abs(), offset.dy.abs());
       }

--- a/lib/src/get_position.dart
+++ b/lib/src/get_position.dart
@@ -28,6 +28,7 @@ class GetPosition {
     required this.screenWidth,
     required this.screenHeight,
     this.padding = EdgeInsets.zero,
+    this.adjustWidthSize = 0.0,
   }) {
     getRenderBox();
   }
@@ -36,6 +37,7 @@ class GetPosition {
   final EdgeInsets padding;
   final double screenWidth;
   final double screenHeight;
+  final double adjustWidthSize;
 
   late final RenderBox? _box;
   late final Offset? _boxOffset;
@@ -46,7 +48,10 @@ class GetPosition {
       _box = renderBox;
       final offset = _box?.globalToLocal(Offset.zero);
       if (offset != null) {
-        _boxOffset = Offset(offset.dx.abs(), offset.dy.abs());
+        _boxOffset = Offset(
+          offset.dx.abs() - adjustWidthSize,
+          offset.dy.abs(),
+        );
       }
     }
   }

--- a/lib/src/layout_overlays.dart
+++ b/lib/src/layout_overlays.dart
@@ -65,10 +65,14 @@ class AnchoredOverlay extends StatelessWidget {
             // To calculate the "anchor" point we grab the render box of
             // our parent Container and then we find the center of that box.
             final box = context.findRenderObject() as RenderBox;
-            final topLeft =
-                box.size.topLeft(box.localToGlobal(const Offset(0.0, 0.0)));
-            final bottomRight =
-                box.size.bottomRight(box.localToGlobal(const Offset(0.0, 0.0)));
+            final offset = box.globalToLocal(Offset.zero);
+            final positiveOffset = Offset(offset.dx.abs(), offset.dy.abs());
+            final topLeft = box.size.topLeft(
+              positiveOffset,
+            );
+            final bottomRight = box.size.bottomRight(
+              positiveOffset,
+            );
             Rect anchorBounds;
             anchorBounds = (topLeft.dx.isNaN ||
                     topLeft.dy.isNaN ||

--- a/lib/src/layout_overlays.dart
+++ b/lib/src/layout_overlays.dart
@@ -47,12 +47,14 @@ class AnchoredOverlay extends StatelessWidget {
   final bool showOverlay;
   final OverlayBuilderCallback? overlayBuilder;
   final Widget? child;
+  final double adjustWidthSize;
 
   const AnchoredOverlay({
     Key? key,
     this.showOverlay = false,
     this.overlayBuilder,
     this.child,
+    this.adjustWidthSize = 0.0,
   }) : super(key: key);
 
   @override
@@ -66,7 +68,10 @@ class AnchoredOverlay extends StatelessWidget {
             // our parent Container and then we find the center of that box.
             final box = context.findRenderObject() as RenderBox;
             final offset = box.globalToLocal(Offset.zero);
-            final positiveOffset = Offset(offset.dx.abs(), offset.dy.abs());
+            final positiveOffset = Offset(
+              offset.dx.abs() - adjustWidthSize,
+              offset.dy.abs(),
+            );
             final topLeft = box.size.topLeft(
               positiveOffset,
             );

--- a/lib/src/showcase.dart
+++ b/lib/src/showcase.dart
@@ -244,6 +244,10 @@ class Showcase extends StatefulWidget {
   /// will still provide a callback.
   final VoidCallback? onBarrierClick;
 
+  /// A way to adjust the target offset calculation
+  /// if you limited the app size
+  final double adjustWidthSize;
+
   const Showcase({
     required this.key,
     required this.description,
@@ -288,6 +292,7 @@ class Showcase extends StatefulWidget {
     this.titleTextDirection,
     this.descriptionTextDirection,
     this.onBarrierClick,
+    this.adjustWidthSize = 0.0,
   })  : height = null,
         width = null,
         container = null,
@@ -325,6 +330,7 @@ class Showcase extends StatefulWidget {
     this.disableDefaultTargetGestures = false,
     this.tooltipPosition,
     this.onBarrierClick,
+    this.adjustWidthSize = 0.0,
   })  : showArrow = false,
         onToolTipClick = null,
         scaleAnimationDuration = const Duration(milliseconds: 300),
@@ -373,8 +379,17 @@ class _ShowcaseState extends State<Showcase> {
         padding: widget.targetPadding,
         screenWidth: MediaQuery.of(context).size.width,
         screenHeight: MediaQuery.of(context).size.height,
+        adjustWidthSize: widget.adjustWidthSize,
       );
       showOverlay();
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant Showcase oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.adjustWidthSize != oldWidget.adjustWidthSize) {
+      setState(() {});
     }
   }
 
@@ -415,16 +430,23 @@ class _ShowcaseState extends State<Showcase> {
     if (_enableShowcase) {
       return AnchoredOverlay(
         overlayBuilder: (context, rectBound, offset) {
-          final size = MediaQuery.of(context).size;
+          final screenSize = MediaQuery.of(context).size;
           position = GetPosition(
             key: widget.key,
             padding: widget.targetPadding,
-            screenWidth: size.width,
-            screenHeight: size.height,
+            screenWidth: screenSize.width,
+            screenHeight: screenSize.height,
+            adjustWidthSize: widget.adjustWidthSize,
           );
-          return buildOverlayOnTarget(offset, rectBound.size, rectBound, size);
+          return _buildOverlayOnTarget(
+            offset,
+            rectBound.size,
+            rectBound,
+            screenSize,
+          );
         },
         showOverlay: true,
+        adjustWidthSize: widget.adjustWidthSize,
         child: widget.child,
       );
     }
@@ -470,7 +492,7 @@ class _ShowcaseState extends State<Showcase> {
     _isTooltipDismissed = false;
   }
 
-  Widget buildOverlayOnTarget(
+  Widget _buildOverlayOnTarget(
     Offset offset,
     Size size,
     Rect rectBound,

--- a/lib/src/showcase.dart
+++ b/lib/src/showcase.dart
@@ -99,6 +99,11 @@ class Showcase extends StatefulWidget {
   /// Custom tooltip widget when [Showcase.withWidget] is used.
   final Widget? container;
 
+  /// Custom tooltip widget builder when [Showcase.withWidget] is used.
+  /// it provides the left offset position based on
+  /// the target center
+  final Widget Function(double)? containerBuilder;
+
   /// Defines background color for tooltip widget.
   ///
   /// Default to [Colors.white]
@@ -296,6 +301,7 @@ class Showcase extends StatefulWidget {
   })  : height = null,
         width = null,
         container = null,
+        containerBuilder = null,
         assert(overlayOpacity >= 0.0 && overlayOpacity <= 1.0,
             "overlay opacity must be between 0 and 1."),
         assert(onTargetClick == null || disposeOnTap != null,
@@ -308,6 +314,7 @@ class Showcase extends StatefulWidget {
     required this.height,
     required this.width,
     required this.container,
+    this.containerBuilder,
     required this.child,
     this.targetShapeBorder = const RoundedRectangleBorder(
       borderRadius: BorderRadius.all(
@@ -573,6 +580,7 @@ class _ShowcaseState extends State<Showcase> {
             titleTextStyle: widget.titleTextStyle,
             descTextStyle: widget.descTextStyle,
             container: widget.container,
+            containerBuilder: widget.containerBuilder,
             tooltipBackgroundColor: widget.tooltipBackgroundColor,
             textColor: widget.textColor,
             showArrow: widget.showArrow,

--- a/lib/src/tooltip_widget.dart
+++ b/lib/src/tooltip_widget.dart
@@ -480,7 +480,7 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
       children: <Widget>[
         Positioned(
           left: _getSpace(),
-          top: contentY - 10,
+          top: contentY + (widget.disableMovingAnimation? 10: -10),
           child: FractionalTranslation(
             translation: Offset(0.0, contentFractionalOffset as double),
             child: SlideTransition(

--- a/lib/src/tooltip_widget.dart
+++ b/lib/src/tooltip_widget.dart
@@ -32,7 +32,7 @@ const _kDefaultPaddingFromParent = 14.0;
 
 class ToolTipWidget extends StatefulWidget {
   final GetPosition? position;
-  final Offset? offset;
+  final Offset offset;
   final Size? screenSize;
   final String? title;
   final TextAlign? titleAlignment;
@@ -61,6 +61,7 @@ class ToolTipWidget extends StatefulWidget {
   final EdgeInsets? descriptionPadding;
   final TextDirection? titleTextDirection;
   final TextDirection? descriptionTextDirection;
+  final Widget Function(double)? containerBuilder;
 
   const ToolTipWidget({
     Key? key,
@@ -94,6 +95,7 @@ class ToolTipWidget extends StatefulWidget {
     this.descriptionPadding,
     this.titleTextDirection,
     this.descriptionTextDirection,
+    this.containerBuilder,
   }) : super(key: key);
 
   @override
@@ -207,7 +209,7 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
   double _getSpace() {
     var space = widget.position!.getCenter() - (widget.contentWidth! / 2);
     if (space + widget.contentWidth! > widget.screenSize!.width) {
-      space = widget.screenSize!.width - widget.contentWidth! - 8;
+      space = (widget.screenSize!.width - widget.contentWidth!) / 2;
     } else if (space < (widget.contentWidth! / 2)) {
       space = 16;
     }
@@ -480,7 +482,7 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
       children: <Widget>[
         Positioned(
           left: _getSpace(),
-          top: contentY + (widget.disableMovingAnimation? 10: -10),
+          top: contentY + (widget.disableMovingAnimation ? 10 : -10),
           child: FractionalTranslation(
             translation: Offset(0.0, contentFractionalOffset as double),
             child: SlideTransition(
@@ -501,7 +503,10 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
                     child: Center(
                       child: MeasureSize(
                         onSizeChange: onSizeChange,
-                        child: widget.container,
+                        child: widget.containerBuilder?.call(
+                              ((widget.position?.getLeft() ?? 0.0) + 16),
+                            ) ??
+                            widget.container,
                       ),
                     ),
                   ),

--- a/lib/src/tooltip_widget.dart
+++ b/lib/src/tooltip_widget.dart
@@ -494,11 +494,10 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
                 color: Colors.transparent,
                 child: GestureDetector(
                   onTap: widget.onTooltipTap,
-                  child: Container(
+                  child: Padding(
                     padding: EdgeInsets.only(
                       top: paddingTop,
                     ),
-                    color: Colors.transparent,
                     child: Center(
                       child: MeasureSize(
                         onSizeChange: onSizeChange,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: showcaseview
 description: A Flutter package to Showcase/Highlight widgets step by step.
-version: 2.0.3
+version: 2.0.4
 homepage: https://github.com/simformsolutions/flutter_showcaseview
 issue_tracker: https://github.com/simformsolutions/flutter_showcaseview/issues
 


### PR DESCRIPTION

# Description

I have run into the issue of getting the target widget position incorrectly, this happened in emulator, real device and on browser.
After investigation, found out that its caused by `RenderBox.localToGlobal` function not returning the correct widget position on screen. I played around a little bit with it and found the `RenderBox.globalToLocal` which returns a correct position for all cases.

Also, I run into another issue. If your limiting the app width(in web apps) the target & tooltip position won't be correct. To fix that i added a new param `adjustWidthSize` which can be provided and gets subtracted from the Offset.dx.
A way of calculating this is :
```dart
        var adjustWidthSize = 0.0;
        if (kIsWeb) {
          final screenSize = MediaQuery.of(context).size;
          final originalSize = MediaQueryData.fromWindow(window).size;
          adjustWidthSize = (originalSize.width - screenSize.width) / 2;
        }
```

then pass it to the Showcase Widget.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


### Migration instructions

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues

Closes #367, #329


<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
