### PR TITLE
feat: ✨Add staticContainer into ToolTipWidget for a custom tooltip th…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,17 @@
 ## [4.0.0] (unreleased)
 - [BREAKING] Fixed [#457](https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/issues/457) titleAlignment property does not work
-- Feature ✨: Added Action widget for tooltip
+- Feature [#466](https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/pull/466): Added Action widget for tooltip
 - Feature [#475](https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/issues/475) - Add
   feasibility to change margin of tooltip with `toolTipMargin`.
 - Feature [#478](https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/issues/478) - Added
   feasibility to change auto scroll widget alignment `scrollAlignment`.
-- Feature ✨: Added `enableAutoScroll` to `showcase`.
+- Feature [#386](https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/pull/386): Added `enableAutoScroll` to `showcase`.
 - Fix [#489](https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/pull/489) - Fixed
   mounter issue inside the `_scrollIntoView` function
 - Feature [#395](https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/issues/395) -
   Added `floatingActionWidget` to give a static fixed widget at any place on the screen.
+- Feature [#396](https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/pull/396): Added `globalFloatingActionWidget` and `hideFloatingActionWidgetForShowcase` for global
+  static fixed widget
 
 ## [3.0.0]
 - [BREAKING] Fixed [#434](https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/issues/434) removed deprecated text style after Flutter 3.22 follow [migration guide](https://docs.flutter.dev/release/breaking-changes/3-19-deprecations#texttheme)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Feature ✨: Added `enableAutoScroll` to `showcase`.
 - Fix [#489](https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/pull/489) - Fixed
   mounter issue inside the `_scrollIntoView` function
+- Feature [#395](https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/issues/395) -
+  Added `floatingActionWidget` to give a static fixed widget at any place on the screen.
 
 ## [3.0.0]
 - [BREAKING] Fixed [#434](https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/issues/434) removed deprecated text style after Flutter 3.22 follow [migration guide](https://docs.flutter.dev/release/breaking-changes/3-19-deprecations#texttheme)

--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ WidgetsBinding.instance.addPostFrameCallback((_) =>
 | globalTooltipActionConfig | TooltipActionConfig?       |                              | Global tooltip actionbar config                                                |
 | globalTooltipActions      | List<TooltipActionButton>? |                              | Global list of tooltip actions                                                 |
 | scrollAlignment           | double                     | 0.5                          | For Auto scroll widget alignment                                               |
+| globalTooltipActionConfig | FloatingActionWidget       |                              | Global Config for tooltip action to auto apply for all the toolTip             |
+
 
 ## Properties of `Showcase` and `Showcase.withWidget`:
 
@@ -210,6 +212,7 @@ WidgetsBinding.instance.addPostFrameCallback((_) =>
 | tooltipActions               | List<TooltipActionButton>? | []                                               | Provide a list of tooltip actions                                                                  | ✅          | ✅                |
 | tooltipActionConfig          | TooltipActionConfig?       |                                                  | Give configurations (alignment, position, etc...) to the tooltip actionbar                         | ✅          | ✅                |
 | enableAutoScroll             | bool?                      | ShowCaseWidget.enableAutoScroll                  | This is used to override the `ShowCaseWidget.enableAutoScroll` behaviour                           | ✅          | ✅                |
+| floatingActionWidget         | FloatingActionWidget       |                                                  | Provided a floating static action widget to show at any place on the screen                        | ✅          | ✅                |
 
 ## Properties of `TooltipActionButton` and `TooltipActionButton.custom`:
 

--- a/README.md
+++ b/README.md
@@ -136,27 +136,28 @@ WidgetsBinding.instance.addPostFrameCallback((_) =>
 
 ## Properties of `ShowCaseWidget`:
 
-| Name                      | Type                       | Default Behaviour            | Description                                                                    |
-|---------------------------|----------------------------|------------------------------|--------------------------------------------------------------------------------|
-| builder                   | Builder                    |                              |                                                                                |
-| blurValue                 | double                     | 0                            | Provides blur effect on overlay                                                |
-| autoPlay                  | bool                       | false                        | Automatically display Next showcase                                            |
-| autoPlayDelay             | Duration                   | Duration(milliseconds: 2000) | Visibility time of showcase when `autoplay` is enabled                         |
-| enableAutoPlayLock        | bool                       | false                        | Block the user interaction on overlay when autoPlay is enabled.                |
-| enableAutoScroll          | bool                       | false                        | Allows to auto scroll to next showcase so as to make the given target visible. |
-| scrollDuration            | Duration                   | Duration(milliseconds: 300)  | Time duration for auto scrolling                                               |
-| disableBarrierInteraction | bool                       | false                        | Disable barrier interaction                                                    |
-| disableScaleAnimation     | bool                       | false                        | Disable scale transition for all showcases                                     |
-| disableMovingAnimation    | bool                       | false                        | Disable bouncing/moving transition for all showcases                           |
-| onStart                   | Function(int?, GlobalKey)? |                              | Triggered on start of each showcase.                                           |
-| onComplete                | Function(int?, GlobalKey)? |                              | Triggered on completion of each showcase.                                      |
-| onFinish                  | VoidCallback?              |                              | Triggered when all the showcases are completed                                 |
-| enableShowcase            | bool                       | true                         | Enable or disable showcase globally.                                           |
-| toolTipMargin             | double                     | 14                           | For tooltip margin                                                             |
-| globalTooltipActionConfig | TooltipActionConfig?       |                              | Global tooltip actionbar config                                                |
-| globalTooltipActions      | List<TooltipActionButton>? |                              | Global list of tooltip actions                                                 |
-| scrollAlignment           | double                     | 0.5                          | For Auto scroll widget alignment                                               |
-| globalTooltipActionConfig | FloatingActionWidget       |                              | Global Config for tooltip action to auto apply for all the toolTip             |
+| Name                                | Type                                         | Default Behaviour            | Description                                                                    |
+|-------------------------------------|----------------------------------------------|------------------------------|--------------------------------------------------------------------------------|
+| builder                             | Builder                                      |                              |                                                                                |
+| blurValue                           | double                                       | 0                            | Provides blur effect on overlay.                                               |
+| autoPlay                            | bool                                         | false                        | Automatically display Next showcase.                                           |
+| autoPlayDelay                       | Duration                                     | Duration(milliseconds: 2000) | Visibility time of showcase when `autoplay` is enabled.                        |
+| enableAutoPlayLock                  | bool                                         | false                        | Block the user interaction on overlay when autoPlay is enabled.                |
+| enableAutoScroll                    | bool                                         | false                        | Allows to auto scroll to next showcase so as to make the given target visible. |
+| scrollDuration                      | Duration                                     | Duration(milliseconds: 300)  | Time duration for auto scrolling.                                              |
+| disableBarrierInteraction           | bool                                         | false                        | Disable barrier interaction.                                                   |
+| disableScaleAnimation               | bool                                         | false                        | Disable scale transition for all showcases.                                    |
+| disableMovingAnimation              | bool                                         | false                        | Disable bouncing/moving transition for all showcases.                          |
+| onStart                             | Function(int?, GlobalKey)?                   |                              | Triggered on start of each showcase.                                           |
+| onComplete                          | Function(int?, GlobalKey)?                   |                              | Triggered on completion of each showcase.                                      |
+| onFinish                            | VoidCallback?                                |                              | Triggered when all the showcases are completed.                                |
+| enableShowcase                      | bool                                         | true                         | Enable or disable showcase globally.                                           |
+| toolTipMargin                       | double                                       | 14                           | For tooltip margin.                                                            |
+| globalTooltipActionConfig           | TooltipActionConfig?                         |                              | Global tooltip actionbar config.                                               |
+| globalTooltipActions                | List<TooltipActionButton>?                   |                              | Global list of tooltip actions .                                               |
+| scrollAlignment                     | double                                       | 0.5                          | For Auto scroll widget alignment.                                              |
+| globalFloatingActionWidget          | FloatingActionWidget Function(BuildContext)? |                              | Global Config for tooltip action to auto apply for all the toolTip .           |
+| hideFloatingActionWidgetForShowcase | List<GlobalKey>                              | []                           | Hides globalFloatingActionWidget for the provided showcase widget keys.        |
 
 
 ## Properties of `Showcase` and `Showcase.withWidget`:

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -564,6 +564,33 @@ class MailTile extends StatelessWidget {
                     targetBorderRadius: const BorderRadius.all(
                       Radius.circular(150),
                     ),
+                    staticContainer: Column(
+                      mainAxisAlignment: MainAxisAlignment.end,
+                      children: [
+                        Padding(
+                          padding: const EdgeInsets.all(16.0),
+                          child: ElevatedButton(
+                            style: ButtonStyle(
+                              backgroundColor: MaterialStateProperty.all<Color>(
+                                  Theme.of(context).primaryColor),
+                              shape: MaterialStateProperty.all<
+                                  RoundedRectangleBorder>(
+                                RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(18.0),
+                                  side: BorderSide(
+                                    color: Theme.of(context).primaryColor,
+                                    width: 2.0,
+                                  ),
+                                ),
+                              ),
+                            ),
+                            child: const Text('Skip Showcase'),
+                            onPressed: () =>
+                                ShowCaseWidget.of(context).dismiss(),
+                          ),
+                        ),
+                      ],
+                    ),
                     container: Container(
                       padding: const EdgeInsets.all(10),
                       decoration: const BoxDecoration(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -26,6 +26,27 @@ class MyApp extends StatelessWidget {
       debugShowCheckedModeBanner: false,
       home: Scaffold(
         body: ShowCaseWidget(
+          hideFloatingActionWidgetForShowcase: [_lastShowcaseWidget],
+          globalFloatingActionWidget: (showcaseContext) => FloatingActionWidget(
+            left: 16,
+            bottom: 16,
+            child: Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: ElevatedButton(
+                onPressed: ShowCaseWidget.of(showcaseContext).dismiss,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: const Color(0xffEE5366),
+                ),
+                child: const Text(
+                  'Skip',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 15,
+                  ),
+                ),
+              ),
+            ),
+          ),
           onStart: (index, key) {
             log('onStart: $index, $key');
           },
@@ -207,8 +228,18 @@ class _MailPageState extends State<MailPage> {
                                     Showcase(
                                       key: _firstShowcaseWidget,
                                       description: 'Tap to see menu options',
-                                      onBarrierClick: () =>
-                                          debugPrint('Barrier clicked'),
+                                      onBarrierClick: () {
+                                        debugPrint('Barrier clicked');
+                                        debugPrint(
+                                          'Floating Action widget for first '
+                                          'showcase is now hidden',
+                                        );
+                                        ShowCaseWidget.of(context)
+                                            .hideFloatingActionWidgetForKeys([
+                                          _firstShowcaseWidget,
+                                          _lastShowcaseWidget
+                                        ]);
+                                      },
                                       tooltipActionConfig:
                                           const TooltipActionConfig(
                                         alignment: MainAxisAlignment.end,
@@ -262,15 +293,17 @@ class _MailPageState extends State<MailPage> {
                         child: Padding(
                           padding: const EdgeInsets.all(16.0),
                           child: ElevatedButton(
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: const Color(0xffEE5366),
+                            ),
+                            onPressed: ShowCaseWidget.of(context).dismiss,
                             child: const Text(
-                              'Skip Showcase',
+                              'Close Showcase',
                               style: TextStyle(
-                                color: Colors.pink,
+                                color: Colors.white,
                                 fontSize: 15,
                               ),
                             ),
-                            onPressed: () =>
-                                ShowCaseWidget.of(context).dismiss(),
                           ),
                         ),
                       ),
@@ -581,38 +614,6 @@ class MailTile extends StatelessWidget {
                     targetShapeBorder: const CircleBorder(),
                     targetBorderRadius: const BorderRadius.all(
                       Radius.circular(150),
-                    ),
-                    floatingActionWidget: FloatingActionWidget.directional(
-                      textDirection: Directionality.of(context),
-                      start: 0,
-                      bottom: 0,
-                      child: Padding(
-                        padding: const EdgeInsets.all(16.0),
-                        child: ElevatedButton(
-                          style: ButtonStyle(
-                            backgroundColor: MaterialStateProperty.all<Color>(
-                                Theme.of(context).primaryColor),
-                            shape: MaterialStateProperty.all<
-                                RoundedRectangleBorder>(
-                              RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(18.0),
-                                side: BorderSide(
-                                  color: Theme.of(context).primaryColor,
-                                  width: 2.0,
-                                ),
-                              ),
-                            ),
-                          ),
-                          child: const Text(
-                            'Skip Showcase',
-                            style: TextStyle(
-                              color: Colors.white,
-                              fontSize: 15,
-                            ),
-                          ),
-                          onPressed: () => ShowCaseWidget.of(context).dismiss(),
-                        ),
-                      ),
                     ),
                     container: Container(
                       padding: const EdgeInsets.all(10),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -256,6 +256,24 @@ class _MailPageState extends State<MailPage> {
                           "Tap to see profile which contains user's name, profile picture, mobile number and country",
                       tooltipBackgroundColor: Theme.of(context).primaryColor,
                       textColor: Colors.white,
+                      floatingActionWidget: FloatingActionWidget(
+                        left: 16,
+                        bottom: 16,
+                        child: Padding(
+                          padding: const EdgeInsets.all(16.0),
+                          child: ElevatedButton(
+                            child: const Text(
+                              'Skip Showcase',
+                              style: TextStyle(
+                                color: Colors.pink,
+                                fontSize: 15,
+                              ),
+                            ),
+                            onPressed: () =>
+                                ShowCaseWidget.of(context).dismiss(),
+                          ),
+                        ),
+                      ),
                       targetShapeBorder: const CircleBorder(),
                       tooltipActionConfig: const TooltipActionConfig(
                         alignment: MainAxisAlignment.spaceBetween,
@@ -564,32 +582,37 @@ class MailTile extends StatelessWidget {
                     targetBorderRadius: const BorderRadius.all(
                       Radius.circular(150),
                     ),
-                    staticContainer: Column(
-                      mainAxisAlignment: MainAxisAlignment.end,
-                      children: [
-                        Padding(
-                          padding: const EdgeInsets.all(16.0),
-                          child: ElevatedButton(
-                            style: ButtonStyle(
-                              backgroundColor: MaterialStateProperty.all<Color>(
-                                  Theme.of(context).primaryColor),
-                              shape: MaterialStateProperty.all<
-                                  RoundedRectangleBorder>(
-                                RoundedRectangleBorder(
-                                  borderRadius: BorderRadius.circular(18.0),
-                                  side: BorderSide(
-                                    color: Theme.of(context).primaryColor,
-                                    width: 2.0,
-                                  ),
+                    floatingActionWidget: FloatingActionWidget.directional(
+                      textDirection: Directionality.of(context),
+                      start: 0,
+                      bottom: 0,
+                      child: Padding(
+                        padding: const EdgeInsets.all(16.0),
+                        child: ElevatedButton(
+                          style: ButtonStyle(
+                            backgroundColor: MaterialStateProperty.all<Color>(
+                                Theme.of(context).primaryColor),
+                            shape: MaterialStateProperty.all<
+                                RoundedRectangleBorder>(
+                              RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(18.0),
+                                side: BorderSide(
+                                  color: Theme.of(context).primaryColor,
+                                  width: 2.0,
                                 ),
                               ),
                             ),
-                            child: const Text('Skip Showcase'),
-                            onPressed: () =>
-                                ShowCaseWidget.of(context).dismiss(),
                           ),
+                          child: const Text(
+                            'Skip Showcase',
+                            style: TextStyle(
+                              color: Colors.white,
+                              fontSize: 15,
+                            ),
+                          ),
+                          onPressed: () => ShowCaseWidget.of(context).dismiss(),
                         ),
-                      ],
+                      ),
                     ),
                     container: Container(
                       padding: const EdgeInsets.all(10),

--- a/lib/showcaseview.dart
+++ b/lib/showcaseview.dart
@@ -29,3 +29,4 @@ export 'src/models/tooltip_action_config.dart';
 export 'src/showcase.dart';
 export 'src/showcase_widget.dart';
 export 'src/tooltip_action_button_widget.dart';
+export 'src/widget/floating_action_widget.dart';

--- a/lib/src/showcase.dart
+++ b/lib/src/showcase.dart
@@ -96,6 +96,9 @@ class Showcase extends StatefulWidget {
   /// Custom tooltip widget when [Showcase.withWidget] is used.
   final Widget? container;
 
+  /// Custom static tooltip widget when [Showcase.withWidget] is used.
+  final Widget? staticContainer;
+
   /// Defines background color for tooltip widget.
   ///
   /// Default to [Colors.white]
@@ -418,6 +421,7 @@ class Showcase extends StatefulWidget {
   })  : height = null,
         width = null,
         container = null,
+        staticContainer = null,
         assert(overlayOpacity >= 0.0 && overlayOpacity <= 1.0,
             "overlay opacity must be between 0 and 1."),
         assert(onTargetClick == null || disposeOnTap != null,
@@ -484,6 +488,7 @@ class Showcase extends StatefulWidget {
     required this.width,
     required this.container,
     required this.child,
+    this.staticContainer,
     this.targetShapeBorder = const RoundedRectangleBorder(
       borderRadius: BorderRadius.all(
         Radius.circular(8),
@@ -789,6 +794,7 @@ class _ShowcaseState extends State<Showcase> {
             titleTextStyle: widget.titleTextStyle,
             descTextStyle: widget.descTextStyle,
             container: widget.container,
+            staticContainer: widget.staticContainer,
             tooltipBackgroundColor: widget.tooltipBackgroundColor,
             textColor: widget.textColor,
             showArrow: widget.showArrow,

--- a/lib/src/showcase.dart
+++ b/lib/src/showcase.dart
@@ -35,6 +35,7 @@ import 'shape_clipper.dart';
 import 'showcase_widget.dart';
 import 'tooltip_action_button_widget.dart';
 import 'tooltip_widget.dart';
+import 'widget/floating_action_widget.dart';
 
 class Showcase extends StatefulWidget {
   /// A key that is unique across the entire app.
@@ -96,8 +97,9 @@ class Showcase extends StatefulWidget {
   /// Custom tooltip widget when [Showcase.withWidget] is used.
   final Widget? container;
 
-  /// Custom static tooltip widget when [Showcase.withWidget] is used.
-  final Widget? staticContainer;
+  /// Custom static floating action widget to show a static widget anywhere
+  /// on the screen
+  final FloatingActionWidget? floatingActionWidget;
 
   /// Defines background color for tooltip widget.
   ///
@@ -418,10 +420,10 @@ class Showcase extends StatefulWidget {
     this.tooltipActionConfig,
     this.scrollAlignment = 0.5,
     this.enableAutoScroll,
+    this.floatingActionWidget,
   })  : height = null,
         width = null,
         container = null,
-        staticContainer = null,
         assert(overlayOpacity >= 0.0 && overlayOpacity <= 1.0,
             "overlay opacity must be between 0 and 1."),
         assert(onTargetClick == null || disposeOnTap != null,
@@ -471,6 +473,7 @@ class Showcase extends StatefulWidget {
   /// - `toolTipSlideEndDistance`: The distance the tooltip slides in from the edge of the screen (defaults to 7dp).
   /// - `tooltipActions`: A list of custom actions (widgets) to display within the tooltip.
   /// - `tooltipActionConfig`: Configuration options for custom tooltip actions.
+  /// - `floatingActionWidget`: Custom static floating action widget to show a static widget anywhere
   ///
   /// **Differences from default constructor:**
   ///
@@ -488,7 +491,7 @@ class Showcase extends StatefulWidget {
     required this.width,
     required this.container,
     required this.child,
-    this.staticContainer,
+    this.floatingActionWidget,
     this.targetShapeBorder = const RoundedRectangleBorder(
       borderRadius: BorderRadius.all(
         Radius.circular(8),
@@ -794,7 +797,8 @@ class _ShowcaseState extends State<Showcase> {
             titleTextStyle: widget.titleTextStyle,
             descTextStyle: widget.descTextStyle,
             container: widget.container,
-            staticContainer: widget.staticContainer,
+            floatingActionWidget: widget.floatingActionWidget ??
+                showCaseWidgetState.widget.globalFloatingActionWidget,
             tooltipBackgroundColor: widget.tooltipBackgroundColor,
             textColor: widget.textColor,
             showArrow: widget.showArrow,

--- a/lib/src/showcase.dart
+++ b/lib/src/showcase.dart
@@ -562,6 +562,7 @@ class _ShowcaseState extends State<Showcase> {
   RenderBox? rootRenderObject;
 
   late final showCaseWidgetState = ShowCaseWidget.of(context);
+  FloatingActionWidget? _globalFloatingActionWidget;
 
   @override
   void initState() {
@@ -577,6 +578,8 @@ class _ShowcaseState extends State<Showcase> {
     recalculateRootWidgetSize();
 
     if (_enableShowcase) {
+      _globalFloatingActionWidget =
+          showCaseWidgetState.globalFloatingActionWidget?.call(context);
       final size = MediaQuery.of(context).size;
       position ??= GetPosition(
         rootRenderObject: rootRenderObject,
@@ -797,8 +800,8 @@ class _ShowcaseState extends State<Showcase> {
             titleTextStyle: widget.titleTextStyle,
             descTextStyle: widget.descTextStyle,
             container: widget.container,
-            floatingActionWidget: widget.floatingActionWidget ??
-                showCaseWidgetState.widget.globalFloatingActionWidget,
+            floatingActionWidget:
+                widget.floatingActionWidget ?? _globalFloatingActionWidget,
             tooltipBackgroundColor: widget.tooltipBackgroundColor,
             textColor: widget.textColor,
             showArrow: widget.showArrow,

--- a/lib/src/showcase_widget.dart
+++ b/lib/src/showcase_widget.dart
@@ -83,10 +83,14 @@ class ShowCaseWidget extends StatefulWidget {
   /// Enable/disable showcase globally. Enabled by default.
   final bool enableShowcase;
 
+  /// Custom static floating action widget to show a static widget anywhere
+  /// on the screen for all the showcase widget
+  final FloatingActionWidget? globalFloatingActionWidget;
+
   /// Global action to apply on every tooltip widget
   final List<TooltipActionButton>? globalTooltipActions;
 
-  /// Global Config for tooltip action to auto apply for all the toolTip
+  /// Global Config for tooltip action to auto apply for all the toolTip.
   final TooltipActionConfig? globalTooltipActionConfig;
 
   /// A widget that manages multiple Showcase widgets.
@@ -115,6 +119,7 @@ class ShowCaseWidget extends StatefulWidget {
   /// - `enableShowcase`: Enables or disables the showcase functionality globally (defaults to `true`).
   /// - `globalTooltipActions`: A list of custom actions to be added to all tooltips.
   /// - `globalTooltipActionConfig`: Configuration options for the global tooltip actions.
+  /// - `floatingActionWidget`: Custom static floating action widget to show a static widget anywhere for all the showcase widgets
   const ShowCaseWidget({
     required this.builder,
     this.onFinish,
@@ -132,6 +137,7 @@ class ShowCaseWidget extends StatefulWidget {
     this.enableShowcase = true,
     this.globalTooltipActionConfig,
     this.globalTooltipActions,
+    this.globalFloatingActionWidget,
   });
 
   static GlobalKey? activeTargetWidget(BuildContext context) {

--- a/lib/src/tooltip_widget.dart
+++ b/lib/src/tooltip_widget.dart
@@ -29,6 +29,7 @@ import 'get_position.dart';
 import 'measure_size.dart';
 import 'models/tooltip_action_config.dart';
 import 'widget/action_widget.dart';
+import 'widget/floating_action_widget.dart';
 import 'widget/tooltip_slide_transition.dart';
 
 class ToolTipWidget extends StatefulWidget {
@@ -44,7 +45,7 @@ class ToolTipWidget extends StatefulWidget {
   final TextStyle? titleTextStyle;
   final TextStyle? descTextStyle;
   final Widget? container;
-  final Widget? staticContainer;
+  final FloatingActionWidget? floatingActionWidget;
   final Color? tooltipBackgroundColor;
   final Color? textColor;
   final bool showArrow;
@@ -80,7 +81,7 @@ class ToolTipWidget extends StatefulWidget {
     required this.titleTextStyle,
     required this.descTextStyle,
     required this.container,
-    required this.staticContainer,
+    required this.floatingActionWidget,
     required this.tooltipBackgroundColor,
     required this.textColor,
     required this.showArrow,
@@ -472,7 +473,7 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
     }
 
     if (widget.container == null) {
-      return Positioned(
+      final defaultToolTipWidget = Positioned(
         top: contentY,
         left: _getLeft(),
         right: _getRight(),
@@ -653,9 +654,22 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
           ),
         ),
       );
+
+      if (widget.floatingActionWidget != null) {
+        return Stack(
+          fit: StackFit.expand,
+          children: [
+            defaultToolTipWidget,
+            widget.floatingActionWidget!,
+          ],
+        );
+      } else {
+        return defaultToolTipWidget;
+      }
     }
 
     return Stack(
+      fit: StackFit.expand,
       children: <Widget>[
         Positioned(
           left: _getSpace(),
@@ -723,7 +737,7 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
             ),
           ),
         ),
-        if (widget.staticContainer != null) ...[widget.staticContainer!],
+        if (widget.floatingActionWidget != null) widget.floatingActionWidget!,
       ],
     );
   }

--- a/lib/src/tooltip_widget.dart
+++ b/lib/src/tooltip_widget.dart
@@ -44,6 +44,7 @@ class ToolTipWidget extends StatefulWidget {
   final TextStyle? titleTextStyle;
   final TextStyle? descTextStyle;
   final Widget? container;
+  final Widget? staticContainer;
   final Color? tooltipBackgroundColor;
   final Color? textColor;
   final bool showArrow;
@@ -79,6 +80,7 @@ class ToolTipWidget extends StatefulWidget {
     required this.titleTextStyle,
     required this.descTextStyle,
     required this.container,
+    required this.staticContainer,
     required this.tooltipBackgroundColor,
     required this.textColor,
     required this.showArrow,
@@ -652,6 +654,7 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
         ),
       );
     }
+
     return Stack(
       children: <Widget>[
         Positioned(
@@ -720,6 +723,7 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
             ),
           ),
         ),
+        if (widget.staticContainer != null) ...[widget.staticContainer!],
       ],
     );
   }

--- a/lib/src/tooltip_widget.dart
+++ b/lib/src/tooltip_widget.dart
@@ -655,7 +655,9 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
         ),
       );
 
-      if (widget.floatingActionWidget != null) {
+      if (widget.floatingActionWidget == null) {
+        return defaultToolTipWidget;
+      } else {
         return Stack(
           fit: StackFit.expand,
           children: [
@@ -663,8 +665,6 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
             widget.floatingActionWidget!,
           ],
         );
-      } else {
-        return defaultToolTipWidget;
       }
     }
 

--- a/lib/src/widget/floating_action_widget.dart
+++ b/lib/src/widget/floating_action_widget.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+
+class FloatingActionWidget extends StatelessWidget {
+  const FloatingActionWidget({
+    super.key,
+    required this.child,
+    this.right,
+    this.width,
+    this.height,
+    this.left,
+    this.bottom,
+    this.top,
+  });
+
+  /// This is same as the Positioned.directional widget
+  /// Creates a widget that controls where a child of a [Stack] is positioned.
+  ///
+  /// Only two out of the three horizontal values (`start`, `end`,
+  /// [width]), and only two out of the three vertical values ([top],
+  /// [bottom], [height]), can be set. In each case, at least one of
+  /// the three must be null.
+  ///
+  /// If `textDirection` is [TextDirection.rtl], then the `start` argument is
+  /// used for the [right] property and the `end` argument is used for the
+  /// [left] property. Otherwise, if `textDirection` is [TextDirection.ltr],
+  /// then the `start` argument is used for the [left] property and the `end`
+  /// argument is used for the [right] property.
+  factory FloatingActionWidget.directional({
+    Key? key,
+    required TextDirection textDirection,
+    required Widget child,
+    double? start,
+    double? top,
+    double? end,
+    double? bottom,
+    double? width,
+    double? height,
+  }) {
+    /// Default value will be [TextDirection.ltr].
+    var left = start;
+    var right = end;
+    switch (textDirection) {
+      case TextDirection.ltr:
+        break;
+      case TextDirection.rtl:
+        left = end;
+        right = start;
+        break;
+    }
+    return FloatingActionWidget(
+      key: key,
+      left: left,
+      top: top,
+      right: right,
+      bottom: bottom,
+      width: width,
+      height: height,
+      child: child,
+    );
+  }
+
+  /// The widget below this widget in the tree.
+  ///
+  /// {@macro flutter.widgets.ProxyWidget.child}
+  final Widget child;
+
+  /// The distance that the child's left edge is inset from the left of the stack.
+  ///
+  /// Only two out of the three horizontal values ([left], [right], [width]) can be
+  /// set. The third must be null.
+  ///
+  /// If all three are null, the [Stack.alignment] is used to position the child
+  /// horizontally.
+  final double? left;
+
+  /// The distance that the child's top edge is inset from the top of the stack.
+  ///
+  /// Only two out of the three vertical values ([top], [bottom], [height]) can be
+  /// set. The third must be null.
+  ///
+  /// If all three are null, the [Stack.alignment] is used to position the child
+  /// vertically.
+  final double? top;
+
+  /// The distance that the child's right edge is inset from the right of the stack.
+  ///
+  /// Only two out of the three horizontal values ([left], [right], [width]) can be
+  /// set. The third must be null.
+  ///
+  /// If all three are null, the [Stack.alignment] is used to position the child
+  /// horizontally.
+  final double? right;
+
+  /// The distance that the child's bottom edge is inset from the bottom of the stack.
+  ///
+  /// Only two out of the three vertical values ([top], [bottom], [height]) can be
+  /// set. The third must be null.
+  ///
+  /// If all three are null, the [Stack.alignment] is used to position the child
+  /// vertically.
+  final double? bottom;
+
+  /// The child's width.
+  ///
+  /// Only two out of the three horizontal values ([left], [right], [width]) can be
+  /// set. The third must be null.
+  ///
+  /// If all three are null, the [Stack.alignment] is used to position the child
+  /// horizontally.
+  final double? width;
+
+  /// The child's height.
+  ///
+  /// Only two out of the three vertical values ([top], [bottom], [height]) can be
+  /// set. The third must be null.
+  ///
+  /// If all three are null, the [Stack.alignment] is used to position the child
+  /// vertically.
+  final double? height;
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned(
+      key: key,
+      left: left,
+      top: top,
+      right: right,
+      bottom: bottom,
+      width: width,
+      height: height,
+      child: child,
+    );
+  }
+}


### PR DESCRIPTION
feat: ✨Provided a parameter to add a static widget which can be placed anywhere on the screen and is not affected by the animation.

# Description
Implemented a `FloatingActionWidget` to show static widget at any place on the screen. Primarily used for when we want to show another widget (perhaps a 'Skip Showcases' button) which is not affected by the animation that is given to the tooltip.
We have also added a directional constructor for the use cases where directionality is important.


## Checklist
- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
Closes #395

## Sample implementation

[Screen_recording_20241203_180104.webm](https://github.com/user-attachments/assets/3da2c2bc-a6fc-427b-b527-fa5984bb3549)


