### PR TITLE
fix: :ambulance: Dart 2.12 Version Compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [2.1.1]
+- Fixed [#425](https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/issues/425) - Unhandled breaking change in v2.1.0
+
 ## [2.1.0]
 - Feature [#420](https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/pull/420) - Dart SDK Upgrade
 - Fixed [#419](https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/pull/419) - Suppress Text Scale Factor Warning

--- a/lib/src/layout_overlays.dart
+++ b/lib/src/layout_overlays.dart
@@ -184,11 +184,11 @@ class _OverlayBuilderState extends State<OverlayBuilder> {
   void addToOverlay(OverlayEntry overlayEntry) async {
     if (mounted) {
       final showCaseContext = ShowCaseWidget.of(context).context;
-      if (Overlay.maybeOf(showCaseContext) != null) {
-        Overlay.of(showCaseContext).insert(overlayEntry);
-      } else if (Overlay.maybeOf(context) != null) {
-        Overlay.of(context).insert(overlayEntry);
-      }
+      // TODO: switch to Overlay.maybeOf once we support dart 2.19 minimum.
+      final showCaseOverlay =
+          showCaseContext.findAncestorStateOfType<OverlayState>();
+      final overlay = context.findAncestorStateOfType<OverlayState>();
+      (showCaseOverlay ?? overlay)?.insert(overlayEntry);
     }
   }
 

--- a/lib/src/tooltip_widget.dart
+++ b/lib/src/tooltip_widget.dart
@@ -131,7 +131,9 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
     // ignore: deprecated_member_use
     final EdgeInsets viewInsets = EdgeInsets.fromWindowPadding(
       // ignore: deprecated_member_use
-      ambiguate(WidgetsBinding.instance)?.window.viewInsets ?? ViewPadding.zero,
+      ambiguate(WidgetsBinding.instance)?.window.viewInsets ??
+          // ignore: deprecated_member_use
+          WindowPadding.zero,
       // ignore: deprecated_member_use
       ambiguate(WidgetsBinding.instance)?.window.devicePixelRatio ?? 1,
     );
@@ -149,12 +151,16 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
     final titleStyle = widget.titleTextStyle ??
         Theme.of(context)
             .textTheme
-            .titleLarge!
+            // TODO: replace once support for 3.1.0 and above is provided.
+            // ignore: deprecated_member_use
+            .headline6!
             .merge(TextStyle(color: widget.textColor));
     final descriptionStyle = widget.descTextStyle ??
         Theme.of(context)
             .textTheme
-            .titleSmall!
+            // TODO: replace once support for 3.1.0 and above is provided.
+            // ignore: deprecated_member_use
+            .subtitle2!
             .merge(TextStyle(color: widget.textColor));
     final titleLength = widget.title == null
         ? 0
@@ -257,7 +263,7 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
+    ambiguate(WidgetsBinding.instance)?.addPostFrameCallback((_) {
       if (widget.container != null &&
           _customContainerKey.currentContext != null &&
           _customContainerKey.currentContext?.size != null) {
@@ -452,7 +458,9 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
                                         style: widget.titleTextStyle ??
                                             Theme.of(context)
                                                 .textTheme
-                                                .titleLarge!
+                                                // TODO: replace once support for 3.1.0 and above is provided.
+                                                // ignore: deprecated_member_use
+                                                .headline6!
                                                 .merge(
                                                   TextStyle(
                                                     color: widget.textColor,
@@ -471,7 +479,9 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
                                       style: widget.descTextStyle ??
                                           Theme.of(context)
                                               .textTheme
-                                              .titleSmall!
+                                              // TODO: replace once support for 3.1.0 and above is provided.
+                                              // ignore: deprecated_member_use
+                                              .subtitle2!
                                               .merge(
                                                 TextStyle(
                                                   color: widget.textColor,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: showcaseview
 description: A Flutter package to Showcase/Highlight widgets step by step.
-version: 2.1.0
+version: 2.1.1
 homepage: https://github.com/simformsolutions/flutter_showcaseview
 issue_tracker: https://github.com/simformsolutions/flutter_showcaseview/issues
 
@@ -14,6 +14,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.1
+  flutter_lints: 1.0.4
 
 flutter:


### PR DESCRIPTION
# Description
- Removed use of `Overlay.maybeOf` from layout_overlays.dart.
- Downgraded flutter_lints version in pubspec.yaml.
- Wrapped `WidgetsBinding.instance` with `ambiguate` in tooltip_widget.dart.
- Replaced `titleLarge` and `titleSmall` text theme with `headline6` and `subtitle2` in tooltip_widget.dart.
- Version bump 2.1.1.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

## Related Issues
Closes #425 