### PR TITLE
fix: :bug: Fixed RecalculateRootWidgetSize null check issue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [2.1.1]
 - Fixed [#425](https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/issues/425) - Unhandled breaking change in v2.1.0
+- Fixed [#428](https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/issues/428) - _ShowcaseState.recalculateRootWidgetSize null value
 
 ## [2.1.0]
 - Feature [#420](https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/pull/420) - Dart SDK Upgrade

--- a/lib/src/showcase.dart
+++ b/lib/src/showcase.dart
@@ -472,6 +472,7 @@ class _ShowcaseState extends State<Showcase> {
 
   void recalculateRootWidgetSize() {
     ambiguate(WidgetsBinding.instance)?.addPostFrameCallback((_) {
+      if (!mounted) return;
       final rootWidget =
           context.findRootAncestorStateOfType<State<WidgetsApp>>();
       rootRenderObject = rootWidget?.context.findRenderObject() as RenderBox?;


### PR DESCRIPTION
# Description
- Added `mounted` check in `addPostFrameCallback` under `recalculateRootWidgetSize` in `showcase.dart` as to ensure that the operation is only performed if the element is mounted.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
Closes #428 