### PR TITLE
fix: EXCEPTION: FlutterError (Cannot get renderObject of inactive element. #455

### DIFF
--- a/lib/src/layout_overlays.dart
+++ b/lib/src/layout_overlays.dart
@@ -63,36 +63,40 @@ class AnchoredOverlay extends StatelessWidget {
         return OverlayBuilder(
           showOverlay: showOverlay,
           overlayBuilder: (overlayContext) {
-            // To calculate the "anchor" point we grab the render box of
-            // our parent Container and then we find the center of that box.
-            final box = context.findRenderObject() as RenderBox;
+            try {
+              // To calculate the "anchor" point we grab the render box of
+              // our parent Container and then we find the center of that box.
+              final box = context.findRenderObject() as RenderBox;
 
-            final topLeft = box.size.topLeft(
-              box.localToGlobal(
-                const Offset(0.0, 0.0),
-                ancestor: rootRenderObject,
-              ),
-            );
-            final bottomRight = box.size.bottomRight(
-              box.localToGlobal(
-                const Offset(0.0, 0.0),
-                ancestor: rootRenderObject,
-              ),
-            );
-            Rect anchorBounds;
-            anchorBounds = (topLeft.dx.isNaN ||
-                    topLeft.dy.isNaN ||
-                    bottomRight.dx.isNaN ||
-                    bottomRight.dy.isNaN)
-                ? const Rect.fromLTRB(0.0, 0.0, 0.0, 0.0)
-                : Rect.fromLTRB(
-                    topLeft.dx,
-                    topLeft.dy,
-                    bottomRight.dx,
-                    bottomRight.dy,
-                  );
-            final anchorCenter = box.size.center(topLeft);
-            return overlayBuilder!(overlayContext, anchorBounds, anchorCenter);
+              final topLeft = box.size.topLeft(
+                box.localToGlobal(
+                  const Offset(0.0, 0.0),
+                  ancestor: rootRenderObject,
+                ),
+              );
+              final bottomRight = box.size.bottomRight(
+                box.localToGlobal(
+                  const Offset(0.0, 0.0),
+                  ancestor: rootRenderObject,
+                ),
+              );
+              Rect anchorBounds;
+              anchorBounds = (topLeft.dx.isNaN ||
+                  topLeft.dy.isNaN ||
+                  bottomRight.dx.isNaN ||
+                  bottomRight.dy.isNaN)
+                  ? const Rect.fromLTRB(0.0, 0.0, 0.0, 0.0)
+                  : Rect.fromLTRB(
+                topLeft.dx,
+                topLeft.dy,
+                bottomRight.dx,
+                bottomRight.dy,
+              );
+              final anchorCenter = box.size.center(topLeft);
+              return overlayBuilder!(overlayContext, anchorBounds, anchorCenter);
+            } catch(e) {
+              return const Offstage();
+            }
           },
           child: child,
         );

--- a/lib/src/showcase.dart
+++ b/lib/src/showcase.dart
@@ -258,6 +258,10 @@ class Showcase extends StatefulWidget {
   /// Defaults to 14.
   final double toolTipMargin;
 
+  /// RenderObject/Size of the root widget - needed if showcase is in a modal dialog/sheet
+  final RenderObject? rootRenderObject;
+  final Size? rootRenderSize;
+
   const Showcase({
     required this.key,
     required this.description,
@@ -305,6 +309,8 @@ class Showcase extends StatefulWidget {
     this.disableBarrierInteraction = false,
     this.toolTipSlideEndDistance = 7,
     this.toolTipMargin = 14,
+    this.rootRenderObject,
+    this.rootRenderSize,
   })  : height = null,
         width = null,
         container = null,
@@ -346,6 +352,8 @@ class Showcase extends StatefulWidget {
     this.onBarrierClick,
     this.disableBarrierInteraction = false,
     this.toolTipSlideEndDistance = 7,
+    this.rootRenderObject,
+    this.rootRenderSize,
   })  : showArrow = false,
         onToolTipClick = null,
         scaleAnimationDuration = const Duration(milliseconds: 300),
@@ -451,11 +459,11 @@ class _ShowcaseState extends State<Showcase> {
     if (_enableShowcase) {
       return AnchoredOverlay(
         key: showCaseWidgetState.anchoredOverlayKey,
-        rootRenderObject: rootRenderObject,
+        rootRenderObject: widget.rootRenderObject ?? rootRenderObject,
         overlayBuilder: (context, rectBound, offset) {
-          final size = rootWidgetSize ?? MediaQuery.of(context).size;
+          final size = widget.rootRenderSize ?? rootWidgetSize ?? MediaQuery.of(context).size;
           position = GetPosition(
-            rootRenderObject: rootRenderObject,
+            rootRenderObject: widget.rootRenderObject ?? rootRenderObject,
             key: widget.key,
             padding: widget.targetPadding,
             screenWidth: size.width,


### PR DESCRIPTION
# Description
added try/catch around overlay builder in the case showcase widget context is dirty and getRenderBox throws an exception

## Breaking Change?
No, this PR is not a breaking change.

## Related Issues
Closes #455