### PR TITLE
feat: additionalDescriptionWidget Added

### DIFF
--- a/lib/src/showcase.dart
+++ b/lib/src/showcase.dart
@@ -56,6 +56,8 @@ class Showcase extends StatefulWidget {
   /// Represents summary description of target widget
   final String? description;
 
+  final Widget? descriptionStatusWidget;
+
   /// ShapeBorder of the highlighted box when target widget will be showcased.
   ///
   /// Note: If [targetBorderRadius] is specified, this parameter will be ignored.
@@ -256,6 +258,7 @@ class Showcase extends StatefulWidget {
     required this.key,
     required this.description,
     required this.child,
+    this.descriptionStatusWidget,
     this.title,
     this.titleAlignment = TextAlign.start,
     this.descriptionAlignment = TextAlign.start,
@@ -321,6 +324,7 @@ class Showcase extends StatefulWidget {
         Radius.circular(8),
       ),
     ),
+    this.descriptionStatusWidget,
     this.overlayColor = Colors.black45,
     this.targetBorderRadius,
     this.overlayOpacity = 0.75,
@@ -599,6 +603,7 @@ class _ShowcaseState extends State<Showcase> {
             targetPadding: widget.targetPadding,
           ),
           ToolTipWidget(
+            descriptionStatusWidget: widget.descriptionStatusWidget,
             position: position,
             offset: offset,
             screenSize: screenSize,

--- a/lib/src/showcase.dart
+++ b/lib/src/showcase.dart
@@ -54,9 +54,14 @@ class Showcase extends StatefulWidget {
   final TextAlign titleAlignment;
 
   /// Represents summary description of target widget
-  final String? description;
+  final Widget? additionalDescriptionWidget;
 
-  final Widget? descriptionStatusWidget;
+  /// The `additionalDescriptionWidget` allows you to place any desired widget
+  /// below the description text. This can be used to provide additional
+  /// context, status indicators, or any other relevant information
+  /// directly beneath the description.
+
+  final String? description;
 
   /// ShapeBorder of the highlighted box when target widget will be showcased.
   ///
@@ -258,7 +263,7 @@ class Showcase extends StatefulWidget {
     required this.key,
     required this.description,
     required this.child,
-    this.descriptionStatusWidget,
+    this.additionalDescriptionWidget,
     this.title,
     this.titleAlignment = TextAlign.start,
     this.descriptionAlignment = TextAlign.start,
@@ -324,7 +329,7 @@ class Showcase extends StatefulWidget {
         Radius.circular(8),
       ),
     ),
-    this.descriptionStatusWidget,
+    this.additionalDescriptionWidget,
     this.overlayColor = Colors.black45,
     this.targetBorderRadius,
     this.overlayOpacity = 0.75,
@@ -603,7 +608,7 @@ class _ShowcaseState extends State<Showcase> {
             targetPadding: widget.targetPadding,
           ),
           ToolTipWidget(
-            descriptionStatusWidget: widget.descriptionStatusWidget,
+            additionalDescriptionWidget: widget.additionalDescriptionWidget,
             position: position,
             offset: offset,
             screenSize: screenSize,

--- a/lib/src/tooltip_widget.dart
+++ b/lib/src/tooltip_widget.dart
@@ -175,6 +175,9 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
       tooltipWidth = widget.screenSize.width - tooltipScreenEdgePadding;
     } else {
       tooltipWidth = maxTextWidth + tooltipTextPadding;
+      if (tooltipWidth < 200) {
+        tooltipWidth = 200;
+      }
     }
   }
 

--- a/lib/src/tooltip_widget.dart
+++ b/lib/src/tooltip_widget.dart
@@ -38,7 +38,7 @@ class ToolTipWidget extends StatefulWidget {
   final String? title;
   final TextAlign? titleAlignment;
   final String? description;
-  final Widget? descriptionStatusWidget;
+  final Widget? additionalDescriptionWidget;
   final TextAlign? descriptionAlignment;
   final TextStyle? titleTextStyle;
   final TextStyle? descTextStyle;
@@ -73,7 +73,7 @@ class ToolTipWidget extends StatefulWidget {
     required this.title,
     required this.titleAlignment,
     required this.description,
-    required this.descriptionStatusWidget,
+    required this.additionalDescriptionWidget,
     required this.titleTextStyle,
     required this.descTextStyle,
     required this.container,
@@ -175,9 +175,6 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
       tooltipWidth = widget.screenSize.width - tooltipScreenEdgePadding;
     } else {
       tooltipWidth = maxTextWidth + tooltipTextPadding;
-      if (tooltipWidth < 200) {
-        tooltipWidth = 200;
-      }
     }
   }
 
@@ -484,8 +481,8 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
                                                     ),
                                                   ),
                                         ),
-                                        widget.descriptionStatusWidget ??
-                                            const SizedBox()
+                                        widget.additionalDescriptionWidget ??
+                                            const SizedBox(),
                                       ],
                                     ),
                                   ),

--- a/lib/src/tooltip_widget.dart
+++ b/lib/src/tooltip_widget.dart
@@ -38,6 +38,7 @@ class ToolTipWidget extends StatefulWidget {
   final String? title;
   final TextAlign? titleAlignment;
   final String? description;
+  final Widget? descriptionStatusWidget;
   final TextAlign? descriptionAlignment;
   final TextStyle? titleTextStyle;
   final TextStyle? descTextStyle;
@@ -72,6 +73,7 @@ class ToolTipWidget extends StatefulWidget {
     required this.title,
     required this.titleAlignment,
     required this.description,
+    required this.descriptionStatusWidget,
     required this.titleTextStyle,
     required this.descTextStyle,
     required this.container,
@@ -461,20 +463,27 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
                                   Padding(
                                     padding: widget.descriptionPadding ??
                                         EdgeInsets.zero,
-                                    child: Text(
-                                      widget.description!,
-                                      textAlign: widget.descriptionAlignment,
-                                      textDirection:
-                                          widget.descriptionTextDirection,
-                                      style: widget.descTextStyle ??
-                                          Theme.of(context)
-                                              .textTheme
-                                              .titleSmall!
-                                              .merge(
-                                                TextStyle(
-                                                  color: widget.textColor,
-                                                ),
-                                              ),
+                                    child: Column(
+                                      children: [
+                                        Text(
+                                          widget.description!,
+                                          textAlign:
+                                              widget.descriptionAlignment,
+                                          textDirection:
+                                              widget.descriptionTextDirection,
+                                          style: widget.descTextStyle ??
+                                              Theme.of(context)
+                                                  .textTheme
+                                                  .titleSmall!
+                                                  .merge(
+                                                    TextStyle(
+                                                      color: widget.textColor,
+                                                    ),
+                                                  ),
+                                        ),
+                                        widget.descriptionStatusWidget ??
+                                            const SizedBox()
+                                      ],
                                     ),
                                   ),
                                 ],


### PR DESCRIPTION
This PR allows adding any desired widget below the description text. The motivation for this change is to enable adding step bars to sequential descriptions.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require ShowCaseView users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

![simulator_screenshot_C722E949-8F29-4144-BA1B-AB9147620AF7](https://github.com/user-attachments/assets/dcbc2b73-252d-48b9-aa9b-f3c88eda380f)
