### PR TITLE
feat: ✨Provided margin parameter to change margin of the tooltip (#475).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [3.0.1]
+
+- Feature [#475](https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/issues/475) - Add
+  feasibility to change margin of tooltip with `toolTipMargin`.
+
 ## [3.0.0]
 - [BREAKING] Fixed [#434](https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/issues/434) removed deprecated text style after Flutter 3.22 follow [migration guide](https://docs.flutter.dev/release/breaking-changes/3-19-deprecations#texttheme)
 - Updated minimum support to dart sdk 2.18.0

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ WidgetsBinding.instance.addPostFrameCallback((_) =>
 | onComplete                | Function(int?, GlobalKey)? |                              | Triggered on completion of each showcase.                                      |
 | onFinish                  | VoidCallback?              |                              | Triggered when all the showcases are completed                                 |
 | enableShowcase            | bool                       | true                         | Enable or disable showcase globally.                                           |
+| toolTipMargin             | double                     | 14                           | For tooltip margin                                                             |
 
 ## Properties of `Showcase` and `Showcase.withWidget`:
 

--- a/lib/src/showcase.dart
+++ b/lib/src/showcase.dart
@@ -252,6 +252,12 @@ class Showcase extends StatefulWidget {
   /// Defaults to 7.
   final double toolTipSlideEndDistance;
 
+  /// Defines the margin for the tooltip.
+  /// Which is from 0 to [toolTipSlideEndDistance].
+  ///
+  /// Defaults to 14.
+  final double toolTipMargin;
+
   const Showcase({
     required this.key,
     required this.description,
@@ -298,6 +304,7 @@ class Showcase extends StatefulWidget {
     this.onBarrierClick,
     this.disableBarrierInteraction = false,
     this.toolTipSlideEndDistance = 7,
+    this.toolTipMargin = 14,
   })  : height = null,
         width = null,
         container = null,
@@ -359,6 +366,7 @@ class Showcase extends StatefulWidget {
         descriptionPadding = null,
         titleTextDirection = null,
         descriptionTextDirection = null,
+        toolTipMargin = 14,
         assert(overlayOpacity >= 0.0 && overlayOpacity <= 1.0,
             "overlay opacity must be between 0 and 1."),
         assert(onBarrierClick == null || disableBarrierInteraction == false,
@@ -632,6 +640,7 @@ class _ShowcaseState extends State<Showcase> {
             titleTextDirection: widget.titleTextDirection,
             descriptionTextDirection: widget.descriptionTextDirection,
             toolTipSlideEndDistance: widget.toolTipSlideEndDistance,
+            toolTipMargin: widget.toolTipMargin,
           ),
         ],
       ],

--- a/lib/src/tooltip_widget.dart
+++ b/lib/src/tooltip_widget.dart
@@ -29,8 +29,6 @@ import 'get_position.dart';
 import 'measure_size.dart';
 import 'widget/tooltip_slide_transition.dart';
 
-const _kDefaultPaddingFromParent = 14.0;
-
 class ToolTipWidget extends StatefulWidget {
   final GetPosition? position;
   final Offset? offset;
@@ -63,6 +61,7 @@ class ToolTipWidget extends StatefulWidget {
   final TextDirection? titleTextDirection;
   final TextDirection? descriptionTextDirection;
   final double toolTipSlideEndDistance;
+  final double toolTipMargin;
 
   const ToolTipWidget({
     super.key,
@@ -89,6 +88,7 @@ class ToolTipWidget extends StatefulWidget {
     required this.tooltipBorderRadius,
     required this.scaleAnimationDuration,
     required this.scaleAnimationCurve,
+    required this.toolTipMargin,
     this.scaleAnimationAlignment,
     this.isTooltipDismissed = false,
     this.tooltipPosition,
@@ -183,8 +183,8 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
       double leftPositionValue = widget.position!.getCenter() - (width * 0.5);
       if ((leftPositionValue + width) > widget.screenSize.width) {
         return null;
-      } else if ((leftPositionValue) < _kDefaultPaddingFromParent) {
-        return _kDefaultPaddingFromParent;
+      } else if ((leftPositionValue) < widget.toolTipMargin) {
+        return widget.toolTipMargin;
       } else {
         return leftPositionValue;
       }
@@ -202,7 +202,7 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
         final rightPosition = widget.position!.getCenter() + (width * 0.5);
 
         return (rightPosition + width) > widget.screenSize.width
-            ? _kDefaultPaddingFromParent
+            ? widget.toolTipMargin
             : null;
       } else {
         return null;


### PR DESCRIPTION
# Description
<!--
- Added Parameter to change margin of the tooltip
-->


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require ShowCaseView users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->
Closes #475 
<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
## With default value 
<img width="351" alt="image" src="https://github.com/user-attachments/assets/762322dc-b5c6-4d5d-9027-6dc917b38e62">

## With ```toolTipMargin = 10```
<img width="348" alt="image" src="https://github.com/user-attachments/assets/caf420d2-13c9-4147-997b-a2499c1b82d1">
 
