### PR TITLE
fix: AnchoredOverlayKey key init

### DIFF
--- a/lib/src/showcase_widget.dart
+++ b/lib/src/showcase_widget.dart
@@ -152,6 +152,7 @@ class ShowCaseWidgetState extends State<ShowCaseWidget> {
   @override
   void initState() {
     super.initState();
+    anchoredOverlayKey = UniqueKey();
     initRootWidget();
   }
 
@@ -163,7 +164,6 @@ class ShowCaseWidgetState extends State<ShowCaseWidget> {
       rootWidgetSize = rootWidget == null
           ? MediaQuery.of(context).size
           : rootRenderObject?.size;
-      anchoredOverlayKey = UniqueKey();
     });
   }
 

--- a/lib/src/showcase_widget.dart
+++ b/lib/src/showcase_widget.dart
@@ -124,7 +124,7 @@ class ShowCaseWidgetState extends State<ShowCaseWidget> {
   int? activeWidgetId;
   RenderBox? rootRenderObject;
   Size? rootWidgetSize;
-  Key anchoredOverlayKey = UniqueKey();
+  final Key anchoredOverlayKey = UniqueKey();
 
   /// These properties are only here so that it can be accessed by
   /// [Showcase]

--- a/lib/src/showcase_widget.dart
+++ b/lib/src/showcase_widget.dart
@@ -124,7 +124,7 @@ class ShowCaseWidgetState extends State<ShowCaseWidget> {
   int? activeWidgetId;
   RenderBox? rootRenderObject;
   Size? rootWidgetSize;
-  Key? anchoredOverlayKey;
+  Key anchoredOverlayKey = UniqueKey();
 
   /// These properties are only here so that it can be accessed by
   /// [Showcase]
@@ -152,7 +152,6 @@ class ShowCaseWidgetState extends State<ShowCaseWidget> {
   @override
   void initState() {
     super.initState();
-    anchoredOverlayKey = UniqueKey();
     initRootWidget();
   }
 


### PR DESCRIPTION
# Description
ShowCaseWidgetState initializes the `anchoredOverlayKey` in `initRootWidget` after the first frame was rendered (`WidgetsBinding.instance.addPostFrameCallback`). This means that the `Showcase` widget's `AnchoredOverlay` will initially have the `key` property set to null. 

This causes unwanted behavior since when the key is eventually updated in the `AnchoredOverlay`, it will cause its child to get disposed and completely rebuilt. In my case, the child I pass into the `Showcase` widget and (so the `AnchoredOverlay`) is animated and disposing the child breaks its animations. 

I suggest that the `anchoredOverlayKey` in the `ShowCaseWidgetState` is initialized directly in the `initState` or if there is some reason for it to be initialized after the first frame (which I do not believe so), make it part of the `_InheritedShowCaseView` and let the `Showcase` widget pass the update to the `AnchoredOverlay` using `ShowCaseWidget.of...`.

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require ShowCaseView users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
