### PR TITLE
feat: ✨Added on dismiss callback in showcase view widget (#500)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [4.1.0] - (UnRelease)
+- Feature [#500](https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/issues/500) -
+  Added `onDismiss` callback in `ShowCaseWidget` which will trigger whenever `onDismiss` method is
+  called
+
 ## [4.0.1]
 - Fixed [#493](https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/issues/493) - ShowCase.withWidget not showing issue 
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ WidgetsBinding.instance.addPostFrameCallback((_) =>
 | onStart                             | Function(int?, GlobalKey)?                   |                              | Triggered on start of each showcase.                                           |
 | onComplete                          | Function(int?, GlobalKey)?                   |                              | Triggered on completion of each showcase.                                      |
 | onFinish                            | VoidCallback?                                |                              | Triggered when all the showcases are completed.                                |
+| onDismiss                           | OnDismissCallback?                           |                              | Triggered when onDismiss is called                                             |
 | enableShowcase                      | bool                                         | true                         | Enable or disable showcase globally.                                           |
 | toolTipMargin                       | double                                       | 14                           | For tooltip margin.                                                            |
 | globalTooltipActionConfig           | TooltipActionConfig?                         |                              | Global tooltip actionbar config.                                               |

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -89,6 +89,9 @@ class MyApp extends StatelessWidget {
               hideActionWidgetForShowcase: [_lastShowcaseWidget],
             ),
           ],
+          onDismiss: (key) {
+            debugPrint('Dismissed at $key');
+          },
         ),
       ),
     );

--- a/lib/src/showcase_widget.dart
+++ b/lib/src/showcase_widget.dart
@@ -25,7 +25,12 @@ import 'package:flutter/material.dart';
 import '../showcaseview.dart';
 
 typedef FloatingActionBuilderCallback = FloatingActionWidget Function(
-  BuildContext,
+  BuildContext context,
+);
+
+typedef OnDismissCallback = void Function(
+  /// this is the key on which showcase is dismissed
+  GlobalKey? dismissedAt,
 );
 
 class ShowCaseWidget extends StatefulWidget {
@@ -33,6 +38,9 @@ class ShowCaseWidget extends StatefulWidget {
 
   /// Triggered when all the showcases are completed.
   final VoidCallback? onFinish;
+
+  /// Triggered when onDismiss is called
+  final OnDismissCallback? onDismiss;
 
   /// Triggered every time on start of each showcase.
   final Function(int?, GlobalKey)? onStart;
@@ -118,6 +126,7 @@ class ShowCaseWidget extends StatefulWidget {
   /// - `onFinish`: A callback function triggered when all showcases are completed.
   /// - `onStart`: A callback function triggered at the start of each showcase, providing the index and key of the target widget.
   /// - `onComplete`: A callback function triggered at the completion of each showcase, providing the index and key of the target widget.
+  /// - `onDismiss`: A callback function triggered when showcase view is dismissed.
   /// - `autoPlay`: Whether to automatically start showcasing the next widget after a delay (defaults to `false`).
   /// - `autoPlayDelay`: The delay between each showcase during auto-play (defaults to 2 seconds).
   /// - `enableAutoPlayLock`: Whether to block user interaction while auto-play is enabled (defaults to `false`).
@@ -137,6 +146,7 @@ class ShowCaseWidget extends StatefulWidget {
     this.onFinish,
     this.onStart,
     this.onComplete,
+    this.onDismiss,
     this.autoPlay = false,
     this.autoPlayDelay = const Duration(milliseconds: 2000),
     this.enableAutoPlayLock = false,
@@ -322,6 +332,14 @@ class ShowCaseWidgetState extends State<ShowCaseWidget> {
 
   /// Dismiss entire showcase view
   void dismiss() {
+    // This will check if valid active widget id exist or not and based on that
+    // we will return the widget key with `onDismiss` callback or will return
+    // null value.
+    final idNotExist =
+        activeWidgetId == null || ids == null || ids!.length < activeWidgetId!;
+
+    widget.onDismiss?.call(idNotExist ? null : ids?[activeWidgetId!]);
+
     if (mounted) setState(_cleanupAfterSteps);
   }
 


### PR DESCRIPTION
# Description
Added `onDismiss` callback in `ShowCaseWidget` which will trigger whenever `onDismiss` method is
  called

## Checklist

- [X] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [X] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [X] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [X] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
Closes #500 
