### PR TITLE
fix: 🐛 Fixed timer not cancelling when tapped on `TooltipActionButton` (#506)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Fixed [#503](https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/issues/503) - Cursor
   not changing to click mode when it is hovering over the clickable widgets provided by this
   package.
+- Fixed [#506](https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/issues/506) - Timer
+  was not canceling when tapped on `TooltipActionButton` which may cause issue when `autoPlay` is ON.
 
 ## [4.0.1]
 - Fixed [#493](https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/issues/493) - ShowCase.withWidget not showing issue 

--- a/lib/src/showcase.dart
+++ b/lib/src/showcase.dart
@@ -609,6 +609,9 @@ class _ShowcaseState extends State<Showcase> {
             Duration(seconds: showCaseWidgetState.autoPlayDelay.inSeconds),
             _nextIfAny);
       }
+    } else if (timer?.isActive ?? false) {
+      timer?.cancel();
+      timer = null;
     }
   }
 
@@ -649,6 +652,13 @@ class _ShowcaseState extends State<Showcase> {
       );
     }
     return widget.child;
+  }
+
+  @override
+  void dispose() {
+    timer?.cancel();
+    timer = null;
+    super.dispose();
   }
 
   void initRootWidget() {


### PR DESCRIPTION
# Description
Fixed timer not canceling when tapped on `TooltipActionButton`
- When autoplay is enabled, tapping on the TooltipActionButton will move to the next showcase without canceling the previous timer. This won't cause any issues until the user presses the previous button, at which point the old timer will end the showcase earlier than anticipated.


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require ShowCaseView users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->
Closes #506 

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
