### PR TITLE
fix: 🐛 overlay rebuild issue

### DIFF
--- a/lib/src/showcase/showcase_view.dart
+++ b/lib/src/showcase/showcase_view.dart
@@ -339,13 +339,16 @@ class ShowcaseView {
     _onComplete().then(
       (_) {
         if (!_mounted) return;
+        // Update active widget ID before starting the next showcase
         _activeWidgetId = id;
 
         if (_activeWidgetId! >= _ids!.length) {
           _cleanupAfterSteps();
           onFinish?.call();
         } else {
-          _onStart();
+          // Add a short delay before starting the next showcase to ensure proper state update
+          // Then start the new showcase
+          Future.microtask(_onStart);
         }
       },
     );
@@ -414,15 +417,17 @@ class ShowcaseView {
       if (controllerLength == 1 && isAutoScroll) {
         await firstController?.scrollIntoView();
       } else {
+        // Setup showcases after data is updated
         for (var i = 0; i < controllerLength; i++) {
           controllers[i].setupShowcase(shouldUpdateOverlay: i == 0);
         }
       }
     }
 
+    // Cancel any existing timer before setting up a new one
+
     if (autoPlay) {
       _cancelTimer();
-      // Showcase is first.
       final config = _getCurrentActiveControllers.firstOrNull?.config;
       _timer = Timer(
         config?.autoPlayDelay ?? autoPlayDelay,

--- a/lib/src/tooltip/arrow_painter.dart
+++ b/lib/src/tooltip/arrow_painter.dart
@@ -21,6 +21,25 @@
  */
 part of 'tooltip.dart';
 
+class ShowcaseArrow extends StatelessWidget {
+  const ShowcaseArrow({
+    super.key,
+    required this.strokeColor,
+  });
+
+  final Color strokeColor;
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(
+      painter: _ArrowPainter(
+        strokeColor: strokeColor,
+      ),
+      size: const Size(Constants.arrowWidth, Constants.arrowHeight),
+    );
+  }
+}
+
 class _ArrowPainter extends CustomPainter {
   _ArrowPainter({
     this.strokeColor = Colors.black,

--- a/lib/src/tooltip/tooltip_widget.dart
+++ b/lib/src/tooltip/tooltip_widget.dart
@@ -173,7 +173,7 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
                 : SystemMouseCursors.click,
             child: GestureDetector(
               onTap: widget.onTooltipTap,
-              child: Center(child: widget.container ?? const SizedBox.shrink()),
+              child: widget.container ?? const SizedBox.shrink(),
             ),
           )
         : MouseRegion(
@@ -183,7 +183,7 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
             child: GestureDetector(
               onTap: widget.onTooltipTap,
               child: Container(
-                padding: widget.tooltipPadding.copyWith(left: 0, right: 0),
+                padding: widget.tooltipPadding,
                 decoration: BoxDecoration(
                   color: widget.tooltipBackgroundColor,
                   borderRadius: widget.tooltipBorderRadius ??
@@ -194,12 +194,7 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
                   children: <Widget>[
                     if (widget.title case final title?)
                       DefaultTooltipTextWidget(
-                        padding: (widget.titlePadding ?? EdgeInsets.zero).add(
-                          EdgeInsets.only(
-                            left: widget.tooltipPadding.left,
-                            right: widget.tooltipPadding.right,
-                          ),
-                        ),
+                        padding: widget.titlePadding ?? EdgeInsets.zero,
                         text: title,
                         textAlign: widget.titleTextAlign,
                         alignment: widget.titleAlignment,
@@ -212,13 +207,7 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
                       ),
                     if (widget.description case final desc?)
                       DefaultTooltipTextWidget(
-                        padding:
-                            (widget.descriptionPadding ?? EdgeInsets.zero).add(
-                          EdgeInsets.only(
-                            left: widget.tooltipPadding.left,
-                            right: widget.tooltipPadding.right,
-                          ),
-                        ),
+                        padding: widget.descriptionPadding ?? EdgeInsets.zero,
                         text: desc,
                         textAlign: widget.descriptionTextAlign,
                         alignment: widget.descriptionAlignment,
@@ -233,10 +222,6 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
                         widget.tooltipActionConfig.position.isInside)
                       ActionWidget(
                         tooltipActionConfig: widget.tooltipActionConfig,
-                        outsidePadding: EdgeInsets.only(
-                          left: widget.tooltipPadding.left,
-                          right: widget.tooltipPadding.right,
-                        ),
                         alignment: widget.tooltipActionConfig.alignment,
                         crossAxisAlignment:
                             widget.tooltipActionConfig.crossAxisAlignment,
@@ -295,11 +280,8 @@ class _ToolTipWidgetState extends State<ToolTipWidget>
           if (widget.showArrow)
             _TooltipLayoutId(
               id: TooltipLayoutSlot.arrow,
-              child: CustomPaint(
-                painter: _ArrowPainter(
-                  strokeColor: widget.tooltipBackgroundColor,
-                ),
-                size: const Size(Constants.arrowWidth, Constants.arrowHeight),
+              child: ShowcaseArrow(
+                strokeColor: widget.tooltipBackgroundColor,
               ),
             ),
         ],

--- a/lib/src/utils/overlay_manager.dart
+++ b/lib/src/utils/overlay_manager.dart
@@ -78,7 +78,6 @@ class OverlayManager {
       ShowcaseService.instance.updateCurrentScope(scope);
     }
     _shouldShow = show;
-    _rebuild();
     _sync();
   }
 
@@ -131,6 +130,8 @@ class OverlayManager {
       _hide();
     } else if (!_isShowing && _shouldShow) {
       _show(_getBuilder);
+    } else {
+      _rebuild();
     }
   }
 
@@ -177,6 +178,10 @@ class OverlayManager {
     );
 
     return Stack(
+      // This key is used to force rebuild the overlay when needed.
+      // this key enables `_overlayEntry?.markNeedsBuild();` to detect that
+      // output of the builder has changed.
+      key: ValueKey(firstShowcaseConfig.hashCode),
       children: [
         GestureDetector(
           onTap: firstController.handleBarrierTap,


### PR DESCRIPTION
# Description
- When rebuild is called, it does not update the overlay properly because the builder is returning the same widget, so a key was added.
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require ShowCaseView users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
