### PR TITLE
feat: Expose onFinish and onDismiss listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,13 +344,17 @@ subtitle: Text('Try swiping this item'
 
 ## Functions of `ShowCaseView.get()` and `ShowCaseView.getNamed(scopeName)`:
 
-| Function Name | Description                                         |
-|---------------|-----------------------------------------------------|
-| startShowCase | Starting the showcase                               |
-| next          | Starts next showcase                                |
-| previous      | Starts previous showcase                            |
-| dismiss       | Dismisses all showcases                             |
-| unRegister    | UnRegister all showcases and the showcaseView scope |
+| Function Name           | Description                                         |
+|-------------------------|-----------------------------------------------------|
+| startShowCase           | Starting the showcase                               |
+| next                    | Starts next showcase                                |
+| previous                | Starts previous showcase                            |
+| dismiss                 | Dismisses all showcases                             |
+| addOnFinishCallback     | Listener when showcase is finished                  |
+| removeOnFinishCallback  | Clears OnFinishCallback                             |
+| addOnDismissCallback    | Listener when showcase is dismissed                 |
+| removeOnDismissCallback | Clears OnDismissCallback                            |
+| unRegister              | UnRegister all showcases and the showcaseView scope |
 
 ## Main Contributors
 

--- a/example/lib/detailscreen.dart
+++ b/example/lib/detailscreen.dart
@@ -20,11 +20,27 @@ class _DetailState extends State<Detail> {
     // ShowcaseView then you can register new ShowcaseView
     ShowcaseView.register(scope: scopeName);
     WidgetsBinding.instance.addPostFrameCallback(
-      (_) => ShowcaseView.getNamed(scopeName).startShowCase(
-        [_one],
-        delay: const Duration(milliseconds: 200),
-      ),
+      (_) => ShowcaseView.getNamed(scopeName)
+        ..startShowCase([_one], delay: const Duration(milliseconds: 200))
+        ..addOnFinishCallback(_onShowcaseFinished)
+        ..addOnDismissCallback(_onShowcaseDismissed),
     );
+  }
+
+  @override
+  void dispose() {
+    ShowcaseView.getNamed(scopeName)
+      ..removeOnFinishCallback(_onShowcaseFinished)
+      ..removeOnDismissCallback(_onShowcaseDismissed);
+    super.dispose();
+  }
+
+  void _onShowcaseFinished() {
+    debugPrint("Showcase tour finished!");
+  }
+
+  void _onShowcaseDismissed(GlobalKey? dismissedAt) {
+    debugPrint("Showcase dismissed $dismissedAt");
   }
 
   @override
@@ -51,6 +67,26 @@ class _DetailState extends State<Detail> {
               key: _one,
               title: 'Title',
               description: 'Desc',
+              floatingActionWidget: FloatingActionWidget(
+                left: 16,
+                bottom: 16,
+                child: Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: const Color(0xffEE5366),
+                    ),
+                    onPressed: ShowcaseView.getNamed(scopeName).dismiss,
+                    child: const Text(
+                      'Close Showcase',
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: 15,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
               child: InkWell(
                 onTap: () {},
                 child: const Text(


### PR DESCRIPTION
# Description
Currently, the onFinish and onDismiss callbacks can only be defined when ShowcaseView is registered, which is often at a global level. This forces developers to handle showcase completion logic far from the widget that initiated it, leading to tightly coupled code and state management challenges.

This change introduces a listener pattern, allowing any widget to subscribe to showcase events dynamically.

- Added `addOnFinishCallback` and `removeOnFinishCallback` to allow for dynamic subscription to the showcase completion event.
- Added `addOnDismissCallback` and `removeOnDismissCallback` for the showcase dismissal event.
- Updated the core logic to iterate and invoke all registered listeners when a showcase is finished or dismissed, ensuring backward compatibility with the original global callbacks.
- Ensured that all listener lists are cleared when ShowcaseView is unregistered to prevent memory leaks.

## Usage Example
```dart
class MyFeatureScreen extends StatefulWidget {
  // ...
}

class _MyFeatureScreenState extends State<MyFeatureScreen> {
  void _onShowcaseFinished() {
    // Handle logic after the showcase
  }

  void _onShowcaseDismissed(GlobalKey? dismissedAt) {
    // Handle logic when showcase is dismissed
  }

  @override
  void initState() {
    super.initState();
    WidgetsBinding.instance.addPostFrameCallback((_) {
      ShowcaseView.get().addOnFinishCallback(_onShowcaseFinished);
      ShowcaseView.get().addOnDismissCallback(_onShowcaseDismissed);
    });
  }

  @override
  void dispose() {
    ShowcaseView.get().removeOnFinishCallback(_onShowcaseFinished);
    ShowcaseView.get().removeOnDismissCallback(_onShowcaseDismissed);
    super.dispose();
  }

  @override
  Widget build(BuildContext context) {
    // ...
  }
}
```

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require ShowCaseView users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
Closes #555 

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
