### PR TITLE
fix: fix did update widget Fixes #576

### DIFF
--- a/lib/src/showcase/showcase.dart
+++ b/lib/src/showcase/showcase.dart
@@ -563,6 +563,19 @@ class _ShowcaseState extends State<Showcase> {
     super.didUpdateWidget(oldWidget);
     if (oldWidget == widget) return;
     _updateControllerValues();
+    if(oldWidget.showcaseKey != widget.showcaseKey) {
+      ShowcaseService.instance.removeController(
+        key: oldWidget.showcaseKey,
+        id: _uniqueId,
+        scope: _showCaseWidgetManager.name,
+      );
+      ShowcaseController.register(
+        id: _uniqueId,
+        key: widget.showcaseKey,
+        getState: () => this,
+        showcaseView: _showCaseWidgetManager.showcaseView,
+      );
+    }
   }
 
   @override


### PR DESCRIPTION
fix showcase key change crashes app

# Description
fixes the issue with changing the key of a showcase widget

`class TestStateful extends StatefulWidget {
  const TestStateful({super.key});

  @override
  State<TestStateful> createState() => _TestStatefulState();
}

class _TestStatefulState extends State<TestStateful> {
  int count = 0;

  GlobalKey testKey = GlobalKey();

  @override
  Widget build(BuildContext context) {
    return Column(
      mainAxisSize: MainAxisSize.min,
      children: [
        Counter(count, testKey),
        ElevatedButton(
            onPressed: () => setState(() {
                  count++;
                  testKey = GlobalKey();
                }),
            child: const Icon(Icons.plus_one))
      ],
    );
  }
}


class Counter extends StatelessWidget {
  const Counter(this.count, this.testKey,{super.key});

  final int count;

  final GlobalKey testKey;

  @override
  Widget build(BuildContext context) {
    return Showcase(
      key: testKey,
      title: "testcount",
      child: Text(count.toString()),
    );
  }
}`


## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
#576 


<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/showcaseview/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
