### PR TITLE
fix: 🐛 make Showcase-wrapped widgets clickable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Fixed [#650](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/650) - Fix null-check crash in ShowcaseService.getController during didUpdateWidget. Fixed by @[vatsaltanna-simformsolutions](https://github.com/vatsaltanna-simformsolutions)
 - Fixed [#633](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/633) - Improve showcase flow by consolidating finish logic and handling missing targets. Fixed by @[vasu-nageshri](https://github.com/vasu-nageshri)
-- Fixed [#633](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/633) - Added `ShowcaseView.isTargetRendered` to detect whether a showcase target is currently rendered, replacing the 4.x.x `key.currentContext` / `key.currentWidget` check. Fixed by @[vatsaltanna-simformsolutions](https://github.com/vatsaltanna-simformsolutions)
+- Fixed [#633](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/633) - Added `ShowcaseView.isTargetRendered` to detect whether a showcase target is currently rendered, replacing the 4.x.x `key.currentContext` / `key.currentWidget` check. Fixed by @[vatsaltanna-simformsolutions](https://github.com/vatsaltanna-simformsolutions) 
 - Fixed [#645](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/645) -  Prevent re-entrant calls to _onComplete during rapid barrier taps. Fixed by @[apizon](https://github.com/apizon)
 - Fixed [#639](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/639) - Add null-safety guards for async sequence transitions. Fixed by @[vasu-nageshri](https://github.com/vasu-nageshri)
 - Fixed [#622](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/622) - Resolve Semantics issue when using `go_router` and `showSemanticsDebugger` flag. Fixed by @[Sahil-Simform](https://github.com/Sahil-Simform)
@@ -26,8 +26,8 @@
 
 - Fixed [#576](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/576) - Fixed the showcase key update issue by removing the old controller entry and registering the new key.
 - Fixed [#578](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/578) - Fixed showcase key issue.
-- Fixed [#583](https://github.com/SimformSolutionsPvtLtd/showcaseview/pull/583) - Accommodate
-  over scroll when auto scroll is enabled.
+- Fixed [#583](https://github.com/SimformSolutionsPvtLtd/showcaseview/pull/583) - Accommodate 
+over scroll when auto scroll is enabled.
 
 ## [5.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
-## [5.0.2] (unreleased)
+## [Unreleased]
+
+- Fixed [#650](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/650) - Fix null-check crash in ShowcaseService.getController during didUpdateWidget. Fixed by @[vatsaltanna-simformsolutions](https://github.com/vatsaltanna-simformsolutions)
+- Fixed [#633](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/633) - Improve showcase flow by consolidating finish logic and handling missing targets. Fixed by @[vasu-nageshri](https://github.com/vasu-nageshri)
+- Fixed [#633](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/633) - Added `ShowcaseView.isTargetRendered` to detect whether a showcase target is currently rendered, replacing the 4.x.x `key.currentContext` / `key.currentWidget` check. Fixed by @[vatsaltanna-simformsolutions](https://github.com/vatsaltanna-simformsolutions)
+- Fixed [#645](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/645) -  Prevent re-entrant calls to _onComplete during rapid barrier taps. Fixed by @[apizon](https://github.com/apizon)
+- Fixed [#639](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/639) - Add null-safety guards for async sequence transitions. Fixed by @[vasu-nageshri](https://github.com/vasu-nageshri)
+- Fixed [#622](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/622) - Resolve Semantics issue when using `go_router` and `showSemanticsDebugger` flag. Fixed by @[Sahil-Simform](https://github.com/Sahil-Simform)
+- Fix [#620](https://github.com/SimformSolutionsPvtLtd/showcaseview/pull/620)- Set MouseRegion opaque property to false for improved interaction in TargetWidget, TooltipWrapper, and FloatingActionWidget. Fixed by @[RuslanTsitser](https://github.com/RuslanTsitser)
+
+## [5.0.2]
 
 - Fixed [#590](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/590) - Fixed Rendering issues with scrollable showcase views inside withWidget
 - Fixed [#587](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/587) - Fixed ShowcaseView.withWidget container positioning issues on web
@@ -6,13 +16,12 @@
 - Feature [#600](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/600) - Added dynamic onComplete callback registration with `addOnCompleteCallback` and `removeOnCompleteCallback` methods
 - Fixed [#577](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/577) - Resolve issue where long tooltip text was rendered outside the screen bounds
 - Feature [#586](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/586): Enhance tooltip accessibility using Semantics live region
-- Fix [#620](https://github.com/SimformSolutionsPvtLtd/showcaseview/pull/620): Set MouseRegion opaque property to false for improved interaction in TargetWidget, TooltipWrapper, and
 
 ## [5.0.1]
 
 - Fixed [#576](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/576) - Fixed the showcase key update issue by removing the old controller entry and registering the new key.
 - Fixed [#578](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/578) - Fixed showcase key issue.
-- Fixed [#583](https://github.com/SimformSolutionsPvtLtd/showcaseview/pull/583) - Accommodate 
+- Fixed [#583](https://github.com/SimformSolutionsPvtLtd/showcaseview/pull/583) - Accommodate
   over scroll when auto scroll is enabled.
 
 ## [5.0.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 - Fixed [#576](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/576) - Fixed the showcase key update issue by removing the old controller entry and registering the new key.
 - Fixed [#578](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/578) - Fixed showcase key issue.
 - Fixed [#583](https://github.com/SimformSolutionsPvtLtd/showcaseview/pull/583) - Accommodate 
- over scroll when auto scroll is enabled.
+  over scroll when auto scroll is enabled.
 
 ## [5.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 - Fixed [#576](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/576) - Fixed the showcase key update issue by removing the old controller entry and registering the new key.
 - Fixed [#578](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/578) - Fixed showcase key issue.
 - Fixed [#583](https://github.com/SimformSolutionsPvtLtd/showcaseview/pull/583) - Accommodate 
-over scroll when auto scroll is enabled.
+ over scroll when auto scroll is enabled.
 
 ## [5.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Feature [#600](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/600) - Added dynamic onComplete callback registration with `addOnCompleteCallback` and `removeOnCompleteCallback` methods
 - Fixed [#577](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/577) - Resolve issue where long tooltip text was rendered outside the screen bounds
 - Feature [#586](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/586): Enhance tooltip accessibility using Semantics live region
+- Fix [#620](https://github.com/SimformSolutionsPvtLtd/showcaseview/pull/620): Set MouseRegion opaque property to false for improved interaction in TargetWidget, TooltipWrapper, and
 
 ## [5.0.1]
 

--- a/lib/src/showcase/target_widget.dart
+++ b/lib/src/showcase/target_widget.dart
@@ -97,6 +97,7 @@ class TargetWidget extends StatelessWidget {
       child: disableDefaultChildGestures
           ? IgnorePointer(child: targetWidgetContent)
           : MouseRegion(
+              opaque: false,
               cursor: SystemMouseCursors.click,
               child: targetWidgetContent,
             ),

--- a/lib/src/tooltip/tooltip_wrapper.dart
+++ b/lib/src/tooltip/tooltip_wrapper.dart
@@ -176,6 +176,7 @@ class _ToolTipWrapperState extends State<ToolTipWrapper>
 
     final defaultToolTipWidget = widget.container != null
         ? MouseRegion(
+            opaque: false,
             cursor: widget.onTooltipTap == null
                 ? MouseCursor.defer
                 : SystemMouseCursors.click,
@@ -187,6 +188,7 @@ class _ToolTipWrapperState extends State<ToolTipWrapper>
             ),
           )
         : MouseRegion(
+            opaque: false,
             cursor: widget.onTooltipTap == null
                 ? MouseCursor.defer
                 : SystemMouseCursors.click,

--- a/lib/src/widget/floating_action_widget.dart
+++ b/lib/src/widget/floating_action_widget.dart
@@ -171,7 +171,7 @@ class FloatingActionWidget extends StatelessWidget {
       bottom: bottom,
       width: width,
       height: height,
-      child: Material(color: Colors.transparent, child: child),
+      child: Material(type: MaterialType.transparency, color: Colors.transparent, child: child),
     );
   }
 }


### PR DESCRIPTION
# Description

There was an issue where widgets wrapped with `Showcase` / `Showcase.withWidget` could become non-interactive (especially on desktop/web).

In these cases, the overlay layer (`MouseRegion` / `Material`) could end up capturing pointer events and preventing the underlying widget from receiving them. This meant the wrapped widget would not reliably get events like `onTapDown` and could fail to participate in the gesture arena (taps, swipes, drags).

This PR fixes that by:
- Setting `opaque: false` on `MouseRegion` in `TargetWidget` and `TooltipWrapper`, allowing events to pass through transparent areas.
- Using `Material(type: MaterialType.transparency, ...)` in `FloatingActionWidget`, which also prevents the wrapper layer from blocking pointer interactions (same practical effect as above, even though the exact underlying reason is not fully clear).

As a result, widgets inside `Showcase` behave as expected and remain clickable/gesture-responsive.

## Checklist
- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [ ] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require ShowCaseView users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/showcaseview/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
