### PR TITLE
fix: 🐛 fix semantics issue when using go router (#622)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed [#633](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/633) - Added `ShowcaseView.isTargetRendered` to detect whether a showcase target is currently rendered, replacing the 4.x.x `key.currentContext` / `key.currentWidget` check. Fixed by @[vatsaltanna-simformsolutions](https://github.com/vatsaltanna-simformsolutions) 
 - Fixed [#645](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/645) -  Prevent re-entrant calls to _onComplete during rapid barrier taps. Fixed by @[apizon](https://github.com/apizon)
 - Fixed [#639](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/639) - Add null-safety guards for async sequence transitions. Fixed by @[vasu-nageshri](https://github.com/vasu-nageshri)
+- Fixed [#622](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/622) - Resolve Semantics issue when using `go_router` and `showSemanticsDebugger` flag. Fixed by @[Sahil-Simform](https://github.com/Sahil-Simform)
 
 ## [5.0.2]
 
@@ -19,7 +20,6 @@
   `skipIfTargetNotPresent` property to `showcase_view.dart`
 - Feature [#634](https://github.com/SimformSolutionsPvtLtd/showcaseview/pull/634): Added overlay
   color and opacity to showcase_view and onTargetRectUpdate to showcase
-- Fixed [#622](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/622) - Resolve Semantics issue when using `go_router` and `showSemanticsDebugger` flag
 
 ## [5.0.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   `skipIfTargetNotPresent` property to `showcase_view.dart`
 - Feature [#634](https://github.com/SimformSolutionsPvtLtd/showcaseview/pull/634): Added overlay
   color and opacity to showcase_view and onTargetRectUpdate to showcase
+- Fixed [#622](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/622) - Resolve Semantics issue when using `go_router` and `showSemanticsDebugger` flag
 
 ## [5.0.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed [#577](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/577) - Resolve issue where long tooltip text was rendered outside the screen bounds
 - Feature [#586](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/586): Enhance tooltip accessibility using Semantics live region
 - Feature [#624](https://github.com/SimformSolutionsPvtLtd/showcaseview/pull/624): Added dynamic onStart callback registration with `addOnStartCallback` and `removeOnStartCallback` methods
+- Fixed [#622](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/622) - Resolve Semantics issue when using `go_router` and `showSemanticsDebugger` flag
 
 ## [5.0.1]
 

--- a/lib/src/utils/overlay_manager.dart
+++ b/lib/src/utils/overlay_manager.dart
@@ -217,13 +217,19 @@ class OverlayManager {
 
     // Wrap with other inherited widgets to maintain showcase's context's
     // inherited values.
-    return Directionality(
-      textDirection: inheritedData.textDirection,
-      child: MediaQuery(
-        data: inheritedData.mediaQuery,
-        child: DefaultTextStyle(
-          style: inheritedData.textStyle,
-          child: themedChild,
+    // Wrapping with Semantics to control accessibility based on
+    // `isSemanticsEnabled` flag.
+    return Semantics(
+      liveRegion: showcaseView.semanticEnable,
+      excludeSemantics: !showcaseView.semanticEnable,
+      child: Directionality(
+        textDirection: inheritedData.textDirection,
+        child: MediaQuery(
+          data: inheritedData.mediaQuery,
+          child: DefaultTextStyle(
+            style: inheritedData.textStyle,
+            child: themedChild,
+          ),
         ),
       ),
     );

--- a/lib/src/utils/overlay_manager.dart
+++ b/lib/src/utils/overlay_manager.dart
@@ -217,22 +217,29 @@ class OverlayManager {
 
     // Wrap with other inherited widgets to maintain showcase's context's
     // inherited values.
-    // Wrapping with Semantics to control accessibility based on
-    // `isSemanticsEnabled` flag.
-    return Semantics(
-      liveRegion: showcaseView.semanticEnable,
-      excludeSemantics: !showcaseView.semanticEnable,
-      child: Directionality(
-        textDirection: inheritedData.textDirection,
-        child: MediaQuery(
-          data: inheritedData.mediaQuery,
-          child: DefaultTextStyle(
-            style: inheritedData.textStyle,
-            child: themedChild,
-          ),
+    final overlayContent = Directionality(
+      textDirection: inheritedData.textDirection,
+      child: MediaQuery(
+        data: inheritedData.mediaQuery,
+        child: DefaultTextStyle(
+          style: inheritedData.textStyle,
+          child: themedChild,
         ),
       ),
     );
+
+    // Only add showcase-specific semantics when explicitly enabled via
+    // `showcaseView.semanticEnable`. When disabled, preserve descendant
+    // widgets' default semantics instead of stripping them from the overlay
+    // subtree.
+    if (showcaseView.semanticEnable) {
+      return Semantics(
+        liveRegion: true,
+        child: overlayContent,
+      );
+    }
+
+    return overlayContent;
   }
 
   /// Extracts and returns linked showcase data from controllers.

--- a/lib/src/utils/overlay_manager.dart
+++ b/lib/src/utils/overlay_manager.dart
@@ -213,13 +213,19 @@ class OverlayManager {
 
     // Wrap with other inherited widgets to maintain showcase's context's
     // inherited values.
-    return Directionality(
-      textDirection: inheritedData.textDirection,
-      child: MediaQuery(
-        data: inheritedData.mediaQuery,
-        child: DefaultTextStyle(
-          style: inheritedData.textStyle,
-          child: themedChild,
+    // Wrapping with Semantics to control accessibility based on
+    // `isSemanticsEnabled` flag.
+    return Semantics(
+      liveRegion: showcaseView.semanticEnable,
+      excludeSemantics: !showcaseView.semanticEnable,
+      child: Directionality(
+        textDirection: inheritedData.textDirection,
+        child: MediaQuery(
+          data: inheritedData.mediaQuery,
+          child: DefaultTextStyle(
+            style: inheritedData.textStyle,
+            child: themedChild,
+          ),
         ),
       ),
     );


### PR DESCRIPTION
# Description
While using `go_router` with `showSemanticsDebugger = true`, the title and description are not visible in the semantics debug view, even though accessibility works as expected. This PR resolves the issue.
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require ShowCaseView users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->
Closes #622
<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/showcaseview/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org

Before:
<img width="1080" height="2340" alt="Screenshot_20260122_141032" src="https://github.com/user-attachments/assets/a1cb7d39-502b-4226-b574-04f93d22bfd6" />

After:

<img width="1080" height="2340" alt="Screenshot_20260122_140907" src="https://github.com/user-attachments/assets/bd28b518-ce51-43aa-a1d5-9a70e21d6682" />


