### PR TITLE
fix: change `_controller` from a getter to a late field initialized during registration and add a scope registration check.

### DIFF
--- a/lib/src/showcase/showcase.dart
+++ b/lib/src/showcase/showcase.dart
@@ -538,11 +538,7 @@ class _ShowcaseState extends State<Showcase> {
   late final String _scopeName =
       widget.scope ?? ShowcaseService.instance.getScope().name;
 
-  ShowcaseController get _controller => ShowcaseService.instance.getController(
-        key: widget.showcaseKey,
-        id: _uniqueId,
-        scope: _showCaseWidgetManager.name,
-      );
+  late ShowcaseController _controller;
 
   late ShowcaseScope _showCaseWidgetManager;
 
@@ -553,7 +549,7 @@ class _ShowcaseState extends State<Showcase> {
     super.initState();
     _showCaseWidgetManager =
         ShowcaseService.instance.getScope(scope: _scopeName);
-    ShowcaseController.register(
+    _controller = ShowcaseController.register(
       id: _uniqueId,
       key: widget.showcaseKey,
       getState: () => this,
@@ -581,7 +577,7 @@ class _ShowcaseState extends State<Showcase> {
         id: _uniqueId,
         scope: _showCaseWidgetManager.name,
       );
-      ShowcaseController.register(
+      _controller = ShowcaseController.register(
         id: _uniqueId,
         key: widget.showcaseKey,
         getState: () => this,
@@ -615,6 +611,7 @@ class _ShowcaseState extends State<Showcase> {
   }
 
   void _updateControllerValues() {
+    if (!ShowcaseService.instance.isRegistered(scope: _scopeName)) return;
     final manager = ShowcaseService.instance.getScope(scope: _scopeName);
     if (manager == _showCaseWidgetManager) return;
     _showCaseWidgetManager = manager;


### PR DESCRIPTION


# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->

The issue was caused by race conditions during widget rebuilds or scope transitions where the ShowcaseService state was temporarily out of sync with the Showcase widget.

## `showcase.dart`

### Local Controller Caching

- Converted `_controller` to a local `late` variable.
- Initialized it in `initState`.
- Updated it in `didUpdateWidget` and `_updateControllerValues` **only when necessary**.
- This ensures the controller is always available to the widget without relying on potentially failing service lookups.

### Scope Registration Safety

- Added a guard clause in `_updateControllerValues` to check  
  `ShowcaseService.instance.isRegistered(scope: _scopeName)`  
  before calling `getScope`.
- This prevents exceptions when the scope is temporarily unavailable during updates.


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [X] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [X] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require ShowCaseView users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [X] No, this PR is not a breaking change.


## Related Issues

Fix #597 : **The error is very difficult to reproduce so I am still checking with the Crashlytics if any similar error may still arise**

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/showcaseview/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
