### PR TITLE
fix: :bug: Prevent re-entrant calls to _onComplete during rapid barri…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Fixed [#645](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/645) -  Prevent re-entrant calls to _onComplete during rapid barrier taps
+
 ## [5.0.2]
 
 - Fixed [#590](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/590) - Fixed Rendering issues with scrollable showcase views inside withWidget

--- a/lib/src/showcase/showcase_view.dart
+++ b/lib/src/showcase/showcase_view.dart
@@ -195,6 +195,10 @@ class ShowcaseView {
   /// Whether the manager is mounted and active.
   bool _mounted = true;
 
+  /// Whether a step completion animation is currently in progress.
+  /// Used to prevent re-entrant calls to [_onComplete] from rapid barrier taps.
+  bool _isCompleting = false;
+
   /// Map to store keys for which floating action widget should be hidden.
   late final Map<GlobalKey, bool> _hideFloatingWidgetKeys;
 
@@ -541,30 +545,39 @@ class ShowcaseView {
   ///
   /// Runs reverse animations and triggers completion callbacks.
   Future<void> _onComplete() async {
-    final currentControllers = _getCurrentActiveControllers;
-    final controllerLength = currentControllers.length;
-    if (skipIfTargetNotPresent && controllerLength == 0) {
-      return;
-    }
-
-    await Future.wait([
-      for (var i = 0; i < controllerLength; i++)
-        if (!(currentControllers[i].config.disableScaleAnimation ??
-                disableScaleAnimation) &&
-            currentControllers[i].reverseAnimationCallback != null)
-          currentControllers[i].reverseAnimationCallback!.call(),
-    ]);
-
-    final activeId = _activeWidgetId ?? -1;
-    if (activeId < (_ids?.length ?? activeId)) {
-      onComplete?.call(activeId, _ids![activeId]);
-      // Call all registered onComplete callbacks
-      for (final callback in _onCompleteCallbacks) {
-        callback.call(activeId, _ids![activeId]);
+    // Guard against re-entrant calls (e.g. rapid barrier taps during the
+    // reverse animation await below), which would call reverse() on already-
+    // disposed AnimationControllers and trigger a null-check crash.
+    if (_isCompleting) return;
+    _isCompleting = true;
+    try {
+      final currentControllers = _getCurrentActiveControllers;
+      final controllerLength = currentControllers.length;
+      if (skipIfTargetNotPresent && controllerLength == 0) {
+        return;
       }
-    }
 
-    if (autoPlay) _cancelTimer();
+      await Future.wait([
+        for (var i = 0; i < controllerLength; i++)
+          if (!(currentControllers[i].config.disableScaleAnimation ??
+                  disableScaleAnimation) &&
+              currentControllers[i].reverseAnimationCallback != null)
+            currentControllers[i].reverseAnimationCallback!.call(),
+      ]);
+
+      final activeId = _activeWidgetId ?? -1;
+      if (activeId < (_ids?.length ?? activeId)) {
+        onComplete?.call(activeId, _ids![activeId]);
+        // Call all registered onComplete callbacks
+        for (final callback in _onCompleteCallbacks) {
+          callback.call(activeId, _ids![activeId]);
+        }
+      }
+
+      if (autoPlay) _cancelTimer();
+    } finally {
+      _isCompleting = false;
+    }
   }
 
   /// Cancels auto-play timer if active.

--- a/lib/src/showcase/showcase_view.dart
+++ b/lib/src/showcase/showcase_view.dart
@@ -423,6 +423,8 @@ class ShowcaseView {
   /// - Updates the overlay to reflect current state
   void _changeSequence(ShowcaseProgressType type) {
     assert(_activeWidgetId != null, 'Please ensure to call startShowcase.');
+    // Ignore re-entrant taps while a completion is in progress.
+    if (_isCompleting) return;
     final id = switch (type) {
       ShowcaseProgressType.forward => _activeWidgetId! + 1,
       ShowcaseProgressType.backward => _activeWidgetId! - 1,


### PR DESCRIPTION
# Description

Add _isCompleting boolean guard to prevent concurrent execution of _onComplete()
when rapid barrier taps occur during step transition animations. This prevents
null-check crashes from calling reverse() on already-disposed AnimationControllers.

Fixes crash when user rapidly taps the barrier during showcase step transitions (#645).
Tested if on my app and can confirm I now longer see any assertion failures or unhandled exceptions.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added relevant dartdoc comments with `///`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

## Related Issues

Fixes #645 