### PR TITLE
feat: ✨: Add `arrowAlignment` to control arrow position along tooltip edge (#566)

### DIFF
--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -535,6 +535,44 @@ Showcase(
 )
 ```
 
+## Arrow Alignment
+
+By default, the tooltip arrow is centered on the target widget. Use `arrowAlignment`
+to shift the arrow along the tooltip edge — useful when the tooltip is much wider
+(or taller) than the target, or when the target sits near a screen edge.
+
+The value ranges from `-1.0` (start: left for top/bottom tooltips, top for
+left/right tooltips) to `1.0` (end: right / bottom). `0.0` is the centre of the
+tooltip edge. Pass `null` (the default) to restore the target-centred behaviour.
+
+```dart
+// Arrow shifted toward the left edge of the tooltip
+Showcase(
+  key: _menuKey,
+  description: 'Tap to see menu options',
+  tooltipPosition: TooltipPosition.bottom,
+  arrowAlignment: -0.7,
+  child: Icon(Icons.menu),
+)
+
+// Arrow shifted toward the right edge of the tooltip
+Showcase(
+  key: _profileKey,
+  title: 'Profile',
+  description: 'View your profile',
+  tooltipPosition: TooltipPosition.bottom,
+  arrowAlignment: 0.7,
+  child: ProfileAvatar(),
+)
+
+// Default — arrow is centred on the target widget (existing behaviour)
+Showcase(
+  key: _defaultKey,
+  description: 'No arrowAlignment set',
+  child: MyWidget(),
+)
+```
+
 ## Showcase Control Methods
 
 Programmatically control the showcase flow:

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -235,6 +235,7 @@ class _MailPageState extends State<MailPage> {
                                     Showcase(
                                       key: _firstShowcaseWidget,
                                       description: 'Tap to see menu options',
+                                      arrowAlignment: -0.7,
                                       onBarrierClick: () {
                                         debugPrint('Barrier clicked');
                                         debugPrint(
@@ -290,6 +291,7 @@ class _MailPageState extends State<MailPage> {
                       targetPadding: const EdgeInsets.all(5),
                       key: _two,
                       title: 'Profile',
+                      arrowAlignment: 0.7,
                       description:
                           "Tap to see profile which contains user's name, profile picture, mobile number and country",
                       tooltipBackgroundColor: Theme.of(context).primaryColor,

--- a/lib/src/showcase/showcase.dart
+++ b/lib/src/showcase/showcase.dart
@@ -114,6 +114,7 @@ class Showcase extends StatefulWidget {
     this.targetTooltipGap = 10,
     this.onTargetRectUpdate,
     this.scope,
+    this.arrowAlignment,
   })  : container = null,
         showcaseKey = key,
         assert(
@@ -205,6 +206,7 @@ class Showcase extends StatefulWidget {
     this.targetTooltipGap = 10,
     this.onTargetRectUpdate,
     this.scope,
+    this.arrowAlignment,
   })  : showArrow = false,
         onToolTipClick = null,
         scaleAnimationDuration = const Duration(milliseconds: 300),
@@ -533,6 +535,18 @@ class Showcase extends StatefulWidget {
 
   /// Triggered when target rect is updated.
   final ValueSetter<Rect>? onTargetRectUpdate;
+
+  /// Controls the position of the arrow along the tooltip edge.
+  ///
+  /// When `null` (default), the arrow is centered on the target widget.
+  ///
+  /// Accepts a value from -1.0 to 1.0:
+  /// - `-1.0` — start edge (left for top/bottom tooltips, top for left/right)
+  /// - `0.0`  — center of the tooltip edge
+  /// - `1.0`  — end edge (right for top/bottom tooltips, bottom for left/right)
+  ///
+  /// Only has effect when [showArrow] is `true`.
+  final double? arrowAlignment;
 
   @override
   State<Showcase> createState() => _ShowcaseState();

--- a/lib/src/showcase/showcase_controller.dart
+++ b/lib/src/showcase/showcase_controller.dart
@@ -352,6 +352,7 @@ class ShowcaseController {
               targetTooltipGap: config.targetTooltipGap,
               showcaseController: this,
               semanticEnable: showcaseView.semanticEnable,
+              arrowAlignment: config.arrowAlignment,
             ),
             if (_getFloatingActionWidget case final floatAction?) floatAction,
           ];

--- a/lib/src/tooltip/animated_tooltip_multi_layout.dart
+++ b/lib/src/tooltip/animated_tooltip_multi_layout.dart
@@ -41,6 +41,7 @@ class _AnimatedTooltipMultiLayout extends MultiChildRenderObjectWidget {
     required this.targetPadding,
     required this.showcaseOffset,
     required this.targetTooltipGap,
+    this.arrowAlignment,
     // If we remove this parameter it will cause error in v3.29.0 so ignore
     // ignore: unused_element_parameter
     super.key,
@@ -63,6 +64,7 @@ class _AnimatedTooltipMultiLayout extends MultiChildRenderObjectWidget {
   final EdgeInsets targetPadding;
   final Offset showcaseOffset;
   final double targetTooltipGap;
+  final double? arrowAlignment;
 
   @override
   RenderObject createRenderObject(BuildContext context) {
@@ -84,6 +86,7 @@ class _AnimatedTooltipMultiLayout extends MultiChildRenderObjectWidget {
       targetPadding: targetPadding,
       showcaseOffset: showcaseOffset,
       targetTooltipGap: targetTooltipGap,
+      arrowAlignment: arrowAlignment,
     );
   }
 
@@ -108,6 +111,7 @@ class _AnimatedTooltipMultiLayout extends MultiChildRenderObjectWidget {
       ..gapBetweenContentAndAction = gapBetweenContentAndAction
       ..targetPadding = targetPadding
       ..showcaseOffset = showcaseOffset
-      ..targetTooltipGap = targetTooltipGap;
+      ..targetTooltipGap = targetTooltipGap
+      ..arrowAlignment = arrowAlignment;
   }
 }

--- a/lib/src/tooltip/render_animation_delegate.dart
+++ b/lib/src/tooltip/render_animation_delegate.dart
@@ -49,6 +49,7 @@ class _RenderAnimationDelegate extends _RenderPositionDelegate {
     required super.targetPadding,
     required super.showcaseOffset,
     required super.targetTooltipGap,
+    super.arrowAlignment,
   })  : _scaleController = scaleController,
         _moveController = moveController,
         _scaleAnimation = scaleAnimation,

--- a/lib/src/tooltip/render_position_delegate.dart
+++ b/lib/src/tooltip/render_position_delegate.dart
@@ -55,6 +55,7 @@ class _RenderPositionDelegate extends RenderBox
     required this.targetPadding,
     required this.showcaseOffset,
     required this.targetTooltipGap,
+    this.arrowAlignment,
   });
 
   // Core positioning parameters
@@ -69,6 +70,16 @@ class _RenderPositionDelegate extends RenderBox
   double screenEdgePadding;
   EdgeInsets targetPadding;
   double targetTooltipGap;
+
+  /// Controls the arrow position along the tooltip edge.
+  ///
+  /// When null, the arrow is centered on the target widget (default behavior).
+  /// When provided, the value ranges from -1.0 (start/left/top) to 1.0
+  /// (end/right/bottom), with 0.0 meaning the center of the tooltip edge.
+  ///
+  /// For top/bottom positions: controls horizontal placement.
+  /// For left/right positions: controls vertical placement.
+  double? arrowAlignment;
 
   /// This is used when there is some space around showcaseview as this widget
   /// implementation works in global coordinate system so because of that we
@@ -764,20 +775,24 @@ class _RenderPositionDelegate extends RenderBox
       case TooltipPosition.top:
         // Arrow points down from bottom of tooltip
         arrowBoxParentData.offset = Offset(
-          targetPosition.dx +
-              halfTargetWidth -
-              halfArrowWidth -
-              showcaseOffset.dx,
+          _calculateArrowAlignedX(
+            defaultX: targetPosition.dx +
+                halfTargetWidth -
+                halfArrowWidth -
+                showcaseOffset.dx,
+          ),
           _yOffset + _toolTipBoxSize.height - 2,
         );
 
       case TooltipPosition.bottom:
         // Arrow points up from top of tooltip
         arrowBoxParentData.offset = Offset(
-          targetPosition.dx +
-              halfTargetWidth -
-              halfArrowWidth -
-              showcaseOffset.dx,
+          _calculateArrowAlignedX(
+            defaultX: targetPosition.dx +
+                halfTargetWidth -
+                halfArrowWidth -
+                showcaseOffset.dx,
+          ),
           _yOffset - Constants.arrowHeight + 1,
         );
 
@@ -785,24 +800,62 @@ class _RenderPositionDelegate extends RenderBox
         // Arrow points right from right side of tooltip
         arrowBoxParentData.offset = Offset(
           _xOffset + _toolTipBoxSize.width - halfArrowHeight + 4,
-          targetPosition.dy +
-              halfTargetHeight -
-              halfArrowWidth +
-              4 -
-              showcaseOffset.dy,
+          _calculateArrowAlignedY(
+            defaultY: targetPosition.dy +
+                halfTargetHeight -
+                halfArrowWidth +
+                4 -
+                showcaseOffset.dy,
+          ),
         );
 
       case TooltipPosition.right:
         // Arrow points left from left side of tooltip
         arrowBoxParentData.offset = Offset(
           _xOffset - Constants.arrowHeight - 4,
-          targetPosition.dy +
-              halfTargetHeight -
-              halfArrowHeight +
-              4 -
-              showcaseOffset.dy,
+          _calculateArrowAlignedY(
+            defaultY: targetPosition.dy +
+                halfTargetHeight -
+                halfArrowHeight +
+                4 -
+                showcaseOffset.dy,
+          ),
         );
     }
+  }
+
+  /// Returns the horizontal arrow position for top/bottom tooltips.
+  ///
+  /// When [arrowAlignment] is set, positions the arrow relative to the tooltip
+  /// edge (-1.0 = left, 0.0 = center, 1.0 = right). Otherwise falls back to
+  /// [defaultX] which centers the arrow on the target widget.
+  double _calculateArrowAlignedX({required double defaultX}) {
+    if (arrowAlignment == null) return defaultX;
+    final aligned = _xOffset +
+        (_toolTipBoxSize.width - Constants.arrowWidth) *
+            (arrowAlignment! + 1) /
+            2;
+    return aligned.clamp(
+      _xOffset,
+      _xOffset + _toolTipBoxSize.width - Constants.arrowWidth,
+    );
+  }
+
+  /// Returns the vertical arrow position for left/right tooltips.
+  ///
+  /// When [arrowAlignment] is set, positions the arrow relative to the tooltip
+  /// edge (-1.0 = top, 0.0 = center, 1.0 = bottom). Otherwise falls back to
+  /// [defaultY] which centers the arrow on the target widget.
+  double _calculateArrowAlignedY({required double defaultY}) {
+    if (arrowAlignment == null) return defaultY;
+    final aligned = _yOffset +
+        (_toolTipBoxSize.height - Constants.arrowHeight) *
+            (arrowAlignment! + 1) /
+            2;
+    return aligned.clamp(
+      _yOffset,
+      _yOffset + _toolTipBoxSize.height - Constants.arrowHeight,
+    );
   }
 
   /// Helper function to calculate position based on selected direction

--- a/lib/src/tooltip/tooltip_wrapper.dart
+++ b/lib/src/tooltip/tooltip_wrapper.dart
@@ -73,6 +73,7 @@ class ToolTipWrapper extends StatefulWidget {
     this.descriptionPadding,
     this.titleTextDirection,
     this.descriptionTextDirection,
+    this.arrowAlignment,
     super.key,
   });
 
@@ -103,6 +104,12 @@ class ToolTipWrapper extends StatefulWidget {
   final TextDirection? titleTextDirection;
   final TextDirection? descriptionTextDirection;
   final double toolTipSlideEndDistance;
+
+  /// Controls the arrow position along the tooltip edge.
+  ///
+  /// When null, the arrow is centered on the target widget (default behavior).
+  /// Ranges from -1.0 (start/left/top) to 1.0 (end/right/bottom).
+  final double? arrowAlignment;
   final double toolTipMargin;
   final TooltipActionConfig tooltipActionConfig;
   final List<Widget> tooltipActions;
@@ -247,6 +254,7 @@ class _ToolTipWrapperState extends State<ToolTipWrapper>
                 ?.localToGlobal(Offset.zero) ??
             Offset.zero,
         targetTooltipGap: widget.targetTooltipGap,
+        arrowAlignment: widget.arrowAlignment,
         children: [
           // We have to use UniqueKey here to avoid the issue with the
           // _TooltipLayoutId being reused and causing layout issues


### PR DESCRIPTION
# Description

Adds a new `arrowAlignment` parameter to the `Showcase` widget that lets users control where the arrow is drawn along the tooltip edge, instead of always being centered on the target widget.

When the tooltip is wider or taller than the target widget (e.g. a small icon in the corner of the screen), the arrow always pointed to the horizontal/vertical centre of the tooltip — which may not align with any meaningful part of the UI. This PR makes the arrow position configurable.

The new `arrowAlignment` parameter accepts a `double?` value in the range `-1.0` (start edge) → `0.0` (centre) → `1.0` (end edge). For top/bottom tooltips it controls horizontal position; for left/right tooltips it controls vertical position. Defaults to `null`, which preserves the existing arrow-centering behaviour.

## Demo

https://github.com/user-attachments/assets/bd3cd451-f381-41ef-881f-4d9bd14ff9b0


## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues

Closes #566

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/showcaseview/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
