### PR TITLE
fix: Fix null-check crash in ShowcaseService.getController during didUpdateWidget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+
+- Fixed [#650](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/650) - Fix null-check crash in ShowcaseService.getController during didUpdateWidget.
+
 ## [5.0.2]
 
 - Fixed [#590](https://github.com/SimformSolutionsPvtLtd/showcaseview/issues/590) - Fixed Rendering issues with scrollable showcase views inside withWidget

--- a/lib/src/showcase/showcase.dart
+++ b/lib/src/showcase/showcase.dart
@@ -543,12 +543,6 @@ class _ShowcaseState extends State<Showcase> {
   late final String _scopeName =
       widget.scope ?? ShowcaseService.instance.getScope().name;
 
-  ShowcaseController get _controller => ShowcaseService.instance.getController(
-        key: widget.showcaseKey,
-        id: _uniqueId,
-        scope: _showCaseWidgetManager.name,
-      );
-
   late ShowcaseScope _showCaseWidgetManager;
 
   late final int _uniqueId = UniqueKey().hashCode;
@@ -600,12 +594,18 @@ class _ShowcaseState extends State<Showcase> {
     // This is to support hot reload
     _updateControllerValues();
 
-    _controller.recalculateRootWidgetSize(
-      context,
-      shouldUpdateOverlay:
-          _showCaseWidgetManager.showcaseView.getActiveShowcaseKey ==
-              widget.showcaseKey,
-    );
+    ShowcaseService.instance
+        .getControllerOrNull(
+          key: widget.showcaseKey,
+          id: _uniqueId,
+          scope: _showCaseWidgetManager.name,
+        )
+        ?.recalculateRootWidgetSize(
+          context,
+          shouldUpdateOverlay:
+              _showCaseWidgetManager.showcaseView.getActiveShowcaseKey ==
+                  widget.showcaseKey,
+        );
     return widget.child;
   }
 
@@ -620,11 +620,21 @@ class _ShowcaseState extends State<Showcase> {
   }
 
   void _updateControllerValues() {
+    if (!ShowcaseService.instance.isRegistered(scope: _scopeName)) return;
     final manager = ShowcaseService.instance.getScope(scope: _scopeName);
     if (manager == _showCaseWidgetManager) return;
+    // Fetch the controller from the OLD scope before reassigning the manager,
+    // otherwise we would look it up in the new scope where it hasn't been
+    // registered yet (null-check crash during didUpdateWidget).
+    final existingController = ShowcaseService.instance.getControllerOrNull(
+      key: widget.showcaseKey,
+      id: _uniqueId,
+      scope: _showCaseWidgetManager.name,
+    );
     _showCaseWidgetManager = manager;
+    if (existingController == null) return;
     ShowcaseService.instance.addController(
-      controller: _controller
+      controller: existingController
         ..showcaseView = _showCaseWidgetManager.showcaseView,
       key: widget.showcaseKey,
       id: _uniqueId,

--- a/lib/src/showcase/showcase_service.dart
+++ b/lib/src/showcase/showcase_service.dart
@@ -180,4 +180,12 @@ class ShowcaseService {
     );
     return controller!;
   }
+
+  /// Returns showcase controller for given key and ID, or null if not found.
+  ShowcaseController? getControllerOrNull({
+    required GlobalKey key,
+    required int id,
+    required String scope,
+  }) =>
+      _showcaseViews[scope]?.controllers[key]?[id];
 }


### PR DESCRIPTION
## Summary

Fixes #650 — production crash (`Null check operator used on a null value`) thrown during `didUpdateWidget` / `build` when a `Showcase` widget rebuilds while its scoped controller is not yet registered or has already been disposed.

**Root cause:** `_updateControllerValues()` reassigned `_showCaseWidgetManager` to the new scope first, then called `_controller` (which looked up the controller using the **new** scope name) — but the controller hadn't been registered in the new scope yet, causing a null-check crash. The same race could also crash `build()` and `getScope()` if the scope was torn down mid-transition.

**Changes:**

- `ShowcaseService`: add `getControllerOrNull()` — a null-safe sibling of `getController()` that returns `null` instead of crashing when the controller isn't registered
- `_ShowcaseState._updateControllerValues()`:
  - Guard with `isRegistered` check at entry to prevent `getScope()` from throwing when the scope has already been unregistered
  - Fetch the controller from the **old** scope *before* reassigning `_showCaseWidgetManager`, fixing the ordering bug that caused the null-check crash
- `_ShowcaseState.build()`: use `getControllerOrNull(...)?. recalculateRootWidgetSize(...)` so a missing controller during a race is a no-op rather than a crash
- Remove the now-unused `_controller` getter (the sole caller of the throwing `getController()`)

**No behaviour change in the normal (non-race) path** — in the happy path the controller is always present, so `getControllerOrNull` returns the exact same value as before.

## Test plan

- [ ] Existing showcase flow works end-to-end (single scope, default scope)
- [ ] Named scope flow works end-to-end
- [ ] Rapid navigation to/from a screen hosting `Showcase` widgets no longer crashes
- [ ] Hot reload continues to work (the `build` path for `recalculateRootWidgetSize`)
- [ ] `didUpdateWidget` with a changed `showcaseKey` still re-registers correctly
- [ ] No regression in overlay positioning or tooltip rendering

Closes #650

🤖 Generated with [Claude Code](https://claude.com/claude-code)